### PR TITLE
Feature/wketchum require sequence id digits

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -45,18 +45,19 @@ jobs:
     # Runs a single command using the runners shell
     
     - name: Checkout daq-release
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release
         
     - name: setup dev area
       run: |
-          source /cvmfs/dunedaq.opensciencegrid.org/tools/dbt/latest/env.sh
-          dbt-create.sh -c -n ${{ matrix.link }} dev-${{ matrix.os_name }}
+          source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+          setup_dbt latest || true
+          dbt-create.py -c -n ${{ matrix.link }} dev-${{ matrix.os_name }}
           
     - name: checkout package for CI
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ${{ github.repository }}
     

--- a/include/hdf5libs/HDF5FileLayout.hpp
+++ b/include/hdf5libs/HDF5FileLayout.hpp
@@ -37,7 +37,12 @@ namespace dunedaq {
 ERS_DECLARE_ISSUE(hdf5libs,
                   FileLayoutSequenceIDsCannotBeZero,
                   "Cannot specify 0 digits for sequence IDs in TriggerRecords. Reverting to " << digits,
-                  ((int)digits))
+                  ((uint64_t)digits)) // NOLINT(build/unsigned)
+
+ERS_DECLARE_ISSUE(hdf5libs,
+                  FileLayoutNotEnoughDigitsForPath,
+		  "Number " << number << " has more digits than the max specified of " << digits << ". Using natural width.",
+                  ((uint64_t)number)((uint64_t)digits)) // NOLINT(build/unsigned)
 
 namespace hdf5libs {
 
@@ -168,6 +173,29 @@ private:
    */
   std::map<daqdataformats::GeoID::SystemType, hdf5filelayout::PathParams> m_path_params_map;
 
+  //quick powers of ten lookup
+  constexpr static uint64_t m_powers_ten[] = { 1, //1e0 // NOLINT(build/unsigned)
+					       10, //1e1
+					       100, //1e2
+					       1000, //1e3
+					       10000, //1e4
+					       100000, //1e5
+					       1000000, //1e6
+					       10000000, //1e7
+					       100000000, //1e8
+					       1000000000, //1e9
+					       10000000000, //1e10
+					       100000000000, //1e11
+					       1000000000000, //1e12
+					       10000000000000, //1e13
+					       100000000000000, //1e14
+					       1000000000000000, //1e15
+					       10000000000000000, //1e16
+					       100000000000000000, //1e17
+					       1000000000000000000, //1e18
+					       10000000000000000000  //1e19
+                                             };
+  
   /**
    * @brief Fill path parameters map from FileLayoutParams
    */

--- a/include/hdf5libs/HDF5FileLayout.hpp
+++ b/include/hdf5libs/HDF5FileLayout.hpp
@@ -19,6 +19,7 @@
 #include "daqdataformats/Fragment.hpp"
 #include "daqdataformats/GeoID.hpp"
 #include "daqdataformats/TriggerRecordHeader.hpp"
+#include "logging/Logging.hpp"
 
 #include "nlohmann/json.hpp"
 
@@ -32,6 +33,12 @@
 #include <vector>
 
 namespace dunedaq {
+
+ERS_DECLARE_ISSUE(hdf5libs,
+                  FileLayoutSequenceIDsCannotBeZero,
+                  "Cannot specify 0 digits for sequence IDs in TriggerRecords. Reverting to " << digits,
+                  ((int)digits))
+
 namespace hdf5libs {
 
 class HDF5FileLayout
@@ -95,55 +102,55 @@ public:
    * @brief get the full path for a Fragment dataset based on trig/seq number and element ID
    */
   std::string get_fragment_path(daqdataformats::trigger_number_t trig_num,
-                                daqdataformats::GeoID element_id,
-                                daqdataformats::sequence_number_t seq_num = 0) const;
+                                daqdataformats::sequence_number_t seq_num,
+                                daqdataformats::GeoID element_id) const;
   /**
    * @brief get the full path for a Fragment dataset based on trig/seq number, give element_id pieces
    */
   std::string get_fragment_path(daqdataformats::trigger_number_t trig_num,
+                                daqdataformats::sequence_number_t seq_num,
                                 daqdataformats::GeoID::SystemType type,
                                 uint16_t region_id, // NOLINT(build/unsigned)
-                                uint32_t element_id, // NOLINT(build/unsigned)
-                                daqdataformats::sequence_number_t seq_num = 0) const;
+                                uint32_t element_id) const; // NOLINT(build/unsigned)
 
   /**
    * @brief get the full path for a Fragment dataset based on trig/seq number, give element_id pieces
    */
   std::string get_fragment_path(daqdataformats::trigger_number_t trig_num,
+                                daqdataformats::sequence_number_t seq_num,
                                 const std::string& typestring,
                                 uint16_t region_id, // NOLINT(build/unsigned)
-                                uint32_t element_id, // NOLINT(build/unsigned)
-                                daqdataformats::sequence_number_t seq_num = 0) const;
+                                uint32_t element_id) const; // NOLINT(build/unsigned)
 
   /**
    * @brief get the path for a Fragment type group based on trig/seq number and type
    */
   std::string get_fragment_type_path(daqdataformats::trigger_number_t trig_num,
-                                     daqdataformats::GeoID::SystemType type,
-                                     daqdataformats::sequence_number_t seq_num = 0) const;
+                                     daqdataformats::sequence_number_t seq_num,
+                                     daqdataformats::GeoID::SystemType type) const;
 
   /**
    * @brief get the path for a Fragment type group based on trig/seq number and type
    */
   std::string get_fragment_type_path(daqdataformats::trigger_number_t trig_num,
-                                     std::string typestring,
-                                     daqdataformats::sequence_number_t seq_num = 0) const;
+                                     daqdataformats::sequence_number_t seq_num,
+                                     std::string typestring) const;
 
   /**
    * @brief get the path for a Fragment region group based on trig/seq number,type, and region ID
    */
   std::string get_fragment_region_path(daqdataformats::trigger_number_t trig_num,
+                                       daqdataformats::sequence_number_t seq_num,
                                        daqdataformats::GeoID::SystemType type,
-                                       uint16_t region_id, // NOLINT(build/unsigned)
-                                       daqdataformats::sequence_number_t seq_num = 0) const;
+                                       uint16_t region_id) const; // NOLINT(build/unsigned)
 
   /**
    * @brief get the path for a Fragment region group based on trig/seq number,type, and region ID
    */
   std::string get_fragment_region_path(daqdataformats::trigger_number_t trig_num,
+                                       daqdataformats::sequence_number_t seq_num,
                                        std::string typestring,
-                                       uint16_t region_id, // NOLINT(build/unsigned)
-                                       daqdataformats::sequence_number_t seq_num = 0) const;
+                                       uint16_t region_id) const; // NOLINT(build/unsigned)
 
 private:
   /**
@@ -170,6 +177,12 @@ private:
    * @brief Version0 FileLayout parameters, for backward compatibility
    */
   hdf5filelayout::FileLayoutParams get_v0_file_layout_params();
+
+  /**
+   * @brief Check configuration for any errors.
+   */  
+  void check_config();
+  
 };
 
 } // namespace hdf5libs

--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -155,18 +155,18 @@ public:
 
   std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const std::string& dataset_name);
   std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const daqdataformats::trigger_number_t trig_num,
-                                                         const daqdataformats::GeoID element_id,
-                                                         const daqdataformats::sequence_number_t seq_num = 0);
-  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const daqdataformats::trigger_number_t trig_num,
-                                                         const daqdataformats::GeoID::SystemType type,
+                                                         const daqdataformats::sequence_number_t seq_num,
+                                                         const daqdataformats::GeoID element_id);
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const daqdataformats::trigger_number_t trig_num, 
+                                                         const daqdataformats::sequence_number_t seq_num,
+							 const daqdataformats::GeoID::SystemType type,
                                                          const uint16_t region_id, // NOLINT(build/unsigned)
-                                                         const uint32_t element_id, // NOLINT(build/unsigned)
-                                                         const daqdataformats::sequence_number_t seq_num = 0);
+                                                         const uint32_t element_id); // NOLINT(build/unsigned)
   std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const daqdataformats::trigger_number_t trig_num,
+                                                         const daqdataformats::sequence_number_t seq_num,
                                                          const std::string typestring,
                                                          const uint16_t region_id, // NOLINT(build/unsigned)
-                                                         const uint32_t element_id, // NOLINT(build/unsigned)
-                                                         const daqdataformats::sequence_number_t seq_num = 0);
+                                                         const uint32_t element_id); // NOLINT(build/unsigned)
 
   std::unique_ptr<daqdataformats::TriggerRecordHeader> get_trh_ptr(const std::string& dataset_name);
   std::unique_ptr<daqdataformats::TriggerRecordHeader> get_trh_ptr(const daqdataformats::trigger_number_t trig_num,

--- a/schema/hdf5libs/hdf5filelayout.jsonnet
+++ b/schema/hdf5libs/hdf5filelayout.jsonnet
@@ -35,7 +35,7 @@ local types = {
                 doc="Prefix for the TriggerRecord name"),
         s.field("digits_for_trigger_number", self.count, 6,
                 doc="Number of digits to use for the trigger number in the TriggerRecord name inside the HDF5 file"),
-        s.field("digits_for_sequence_number", self.count, 0,
+        s.field("digits_for_sequence_number", self.count, 4,
                 doc="Number of digits to use for the sequence number in the TriggerRecord name inside the HDF5 file"),
         s.field("trigger_record_header_dataset_name", self.hdf_string, "TriggerRecordHeader",
                 doc="Dataset name for the TriggerRecordHeader"),

--- a/src/HDF5FileLayout.cpp
+++ b/src/HDF5FileLayout.cpp
@@ -42,14 +42,27 @@ void HDF5FileLayout::check_config()
 std::string HDF5FileLayout::get_trigger_number_string(daqdataformats::trigger_number_t trig_num,
 						      daqdataformats::sequence_number_t seq_num) const
 {
-  
+
   std::ostringstream trigger_number_string;
-  trigger_number_string << m_conf_params.trigger_record_name_prefix
-			<< std::setw(m_conf_params.digits_for_trigger_number) << std::setfill('0') << trig_num;
+
+  int width=m_conf_params.digits_for_trigger_number;
   
+  if(trig_num > m_powers_ten[m_conf_params.digits_for_trigger_number]){
+    ers::warning(FileLayoutNotEnoughDigitsForPath(ERS_HERE,trig_num,m_conf_params.digits_for_trigger_number));
+    width=0; // tells it to revert to normal width
+  }
+        
+  trigger_number_string << m_conf_params.trigger_record_name_prefix
+			<< std::setw(width) << std::setfill('0') << trig_num;
+
   if (m_conf_params.digits_for_sequence_number > 0) {
-    trigger_number_string << "." << std::setw(m_conf_params.digits_for_sequence_number) << std::setfill('0')
-			  << seq_num;
+
+      width=m_conf_params.digits_for_sequence_number;
+      if(seq_num > m_powers_ten[m_conf_params.digits_for_sequence_number]){
+	ers::warning(FileLayoutNotEnoughDigitsForPath(ERS_HERE,seq_num,m_conf_params.digits_for_sequence_number));
+	width=0; // tells it to revert to normal width
+      }
+      trigger_number_string << "." << std::setw(width) << std::setfill('0') << seq_num;
   }
   
   return trigger_number_string.str();
@@ -91,13 +104,27 @@ std::vector<std::string> HDF5FileLayout::get_path_elements(const daqdataformats:
   
   // then the region
   std::ostringstream region_string;
-  region_string << path_params.region_name_prefix << std::setw(path_params.digits_for_region_number)
+
+  int width=path_params.digits_for_region_number;  
+  if(fh.element_id.region_id > m_powers_ten[path_params.digits_for_region_number]){
+    ers::warning(FileLayoutNotEnoughDigitsForPath(ERS_HERE,fh.element_id.region_id,path_params.digits_for_region_number));
+    width=0; // tells it to revert to normal width
+  }
+
+  region_string << path_params.region_name_prefix << std::setw(width)
 		<< std::setfill('0') << fh.element_id.region_id;
   path_elements.push_back(region_string.str());
   
   // finally the element
   std::ostringstream element_string;
-  element_string << path_params.element_name_prefix << std::setw(path_params.digits_for_element_number)
+
+  width=path_params.digits_for_element_number;
+  if(fh.element_id.element_id > m_powers_ten[path_params.digits_for_element_number]){
+    ers::warning(FileLayoutNotEnoughDigitsForPath(ERS_HERE,fh.element_id.element_id,path_params.digits_for_element_number));
+    width=0; // tells it to revert to normal width
+  }
+
+  element_string << path_params.element_name_prefix << std::setw(width)
 		 << std::setfill('0') << fh.element_id.element_id;
   path_elements.push_back(element_string.str());
   

--- a/src/HDF5FileLayout.cpp
+++ b/src/HDF5FileLayout.cpp
@@ -47,7 +47,7 @@ std::string HDF5FileLayout::get_trigger_number_string(daqdataformats::trigger_nu
 
   int width=m_conf_params.digits_for_trigger_number;
   
-  if(trig_num > m_powers_ten[m_conf_params.digits_for_trigger_number]){
+  if(trig_num >= m_powers_ten[m_conf_params.digits_for_trigger_number]){
     ers::warning(FileLayoutNotEnoughDigitsForPath(ERS_HERE,trig_num,m_conf_params.digits_for_trigger_number));
     width=0; // tells it to revert to normal width
   }
@@ -58,7 +58,7 @@ std::string HDF5FileLayout::get_trigger_number_string(daqdataformats::trigger_nu
   if (m_conf_params.digits_for_sequence_number > 0) {
 
       width=m_conf_params.digits_for_sequence_number;
-      if(seq_num > m_powers_ten[m_conf_params.digits_for_sequence_number]){
+      if(seq_num >= m_powers_ten[m_conf_params.digits_for_sequence_number]){
 	ers::warning(FileLayoutNotEnoughDigitsForPath(ERS_HERE,seq_num,m_conf_params.digits_for_sequence_number));
 	width=0; // tells it to revert to normal width
       }
@@ -106,7 +106,7 @@ std::vector<std::string> HDF5FileLayout::get_path_elements(const daqdataformats:
   std::ostringstream region_string;
 
   int width=path_params.digits_for_region_number;  
-  if(fh.element_id.region_id > m_powers_ten[path_params.digits_for_region_number]){
+  if(fh.element_id.region_id >= m_powers_ten[path_params.digits_for_region_number]){
     ers::warning(FileLayoutNotEnoughDigitsForPath(ERS_HERE,fh.element_id.region_id,path_params.digits_for_region_number));
     width=0; // tells it to revert to normal width
   }
@@ -119,7 +119,7 @@ std::vector<std::string> HDF5FileLayout::get_path_elements(const daqdataformats:
   std::ostringstream element_string;
 
   width=path_params.digits_for_element_number;
-  if(fh.element_id.element_id > m_powers_ten[path_params.digits_for_element_number]){
+  if(fh.element_id.element_id >= m_powers_ten[path_params.digits_for_element_number]){
     ers::warning(FileLayoutNotEnoughDigitsForPath(ERS_HERE,fh.element_id.element_id,path_params.digits_for_element_number));
     width=0; // tells it to revert to normal width
   }

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -316,7 +316,9 @@ HDF5RawDataFile::get_all_record_numbers()
     if (name.find(".") && get_version() < 2)
       throw IncompatibleFileLayoutVersion(ERS_HERE,get_version(),2,MAX_FILELAYOUT_VERSION);
 
-    record_numbers.insert(std::stoi(name.substr(loc + record_prefix_size)));
+    auto trstring = name.substr(loc + record_prefix_size);
+    trstring.resize(m_file_layout_ptr->get_digits_for_trigger_number());
+    record_numbers.insert(std::stoi(trstring));
   }
 
   return record_numbers;
@@ -403,39 +405,39 @@ HDF5RawDataFile::get_frag_ptr(const std::string& dataset_name)
 
 std::unique_ptr<daqdataformats::Fragment>
 HDF5RawDataFile::get_frag_ptr(const daqdataformats::trigger_number_t trig_num,
-                              const daqdataformats::GeoID element_id,
-                              const daqdataformats::sequence_number_t seq_num)
+                              const daqdataformats::sequence_number_t seq_num,
+                              const daqdataformats::GeoID element_id)
 {
   if(get_version() < 2)
     throw IncompatibleFileLayoutVersion(ERS_HERE,get_version(),2,MAX_FILELAYOUT_VERSION);
 
-  return get_frag_ptr(m_file_layout_ptr->get_fragment_path(trig_num, element_id, seq_num));
+  return get_frag_ptr(m_file_layout_ptr->get_fragment_path(trig_num, seq_num, element_id));
 }
 
 std::unique_ptr<daqdataformats::Fragment>
 HDF5RawDataFile::get_frag_ptr(const daqdataformats::trigger_number_t trig_num,
+                              const daqdataformats::sequence_number_t seq_num,
                               const daqdataformats::GeoID::SystemType type,
                               const uint16_t region_id, // NOLINT(build/unsigned)
-                              const uint32_t element_id, // NOLINT(build/unsigned)
-                              const daqdataformats::sequence_number_t seq_num)
+                              const uint32_t element_id) // NOLINT(build/unsigned)
 {
   if(get_version() < 2)
     throw IncompatibleFileLayoutVersion(ERS_HERE,get_version(),2,MAX_FILELAYOUT_VERSION);
 
-  return get_frag_ptr(m_file_layout_ptr->get_fragment_path(trig_num, type, region_id, element_id, seq_num));
+  return get_frag_ptr(m_file_layout_ptr->get_fragment_path(trig_num, seq_num, type, region_id, element_id));
 }
 
 std::unique_ptr<daqdataformats::Fragment>
 HDF5RawDataFile::get_frag_ptr(const daqdataformats::trigger_number_t trig_num,
+                              const daqdataformats::sequence_number_t seq_num,
                               const std::string typestring,
                               const uint16_t region_id, // NOLINT(build/unsigned)
-                              const uint32_t element_id, // NOLINT(build/unsigned)
-                              const daqdataformats::sequence_number_t seq_num)
+                              const uint32_t element_id) // NOLINT(build/unsigned)
 {
   if(get_version() < 2)
     throw IncompatibleFileLayoutVersion(ERS_HERE,get_version(),2,MAX_FILELAYOUT_VERSION);
 
-  return get_frag_ptr(m_file_layout_ptr->get_fragment_path(trig_num, typestring, region_id, element_id, seq_num));
+  return get_frag_ptr(m_file_layout_ptr->get_fragment_path(trig_num, seq_num, typestring, region_id, element_id));
 }
 
 std::unique_ptr<daqdataformats::TriggerRecordHeader>

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -102,8 +102,8 @@ HDF5RawDataFile::write(const daqdataformats::TriggerRecord& tr)
  */
 void
 HDF5RawDataFile::write(const daqdataformats::TriggerRecordHeader& trh)
-{
-
+{  
+  
   m_recorded_size += do_write(m_file_layout_ptr->get_path_elements(trh),
                               static_cast<const char*>(trh.get_storage_location()),
                               trh.get_total_size_bytes());
@@ -317,7 +317,11 @@ HDF5RawDataFile::get_all_record_numbers()
       throw IncompatibleFileLayoutVersion(ERS_HERE,get_version(),2,MAX_FILELAYOUT_VERSION);
 
     auto trstring = name.substr(loc + record_prefix_size);
-    trstring.resize(m_file_layout_ptr->get_digits_for_trigger_number());
+
+    loc = trstring.find(".");
+    if(loc!=std::string::npos)
+      trstring.resize(loc); //remove anything from '.' onwards
+
     record_numbers.insert(std::stoi(trstring));
   }
 

--- a/test/apps/HDF5LIBS_TestReader.cpp
+++ b/test/apps/HDF5LIBS_TestReader.cpp
@@ -96,13 +96,13 @@ main(int argc, char** argv)
 
   auto first_trig_num = *(trigger_records.begin());
 
-  auto trh_ptr = h5_raw_data_file.get_trh_ptr(first_trig_num);
+  auto trh_ptr = h5_raw_data_file.get_trh_ptr(first_trig_num,0);
   TLOG() << "Trigger Record Headers:";
   TLOG() << "First: " << trh_ptr->get_header();
   TLOG() << "Last: " << h5_raw_data_file.get_trh_ptr(all_trh_paths.back())->get_header();
 
   TLOG() << "Fragment Headers:";
-  TLOG() << "First: " << h5_raw_data_file.get_frag_ptr(first_trig_num, "TPC", 0, 0)->get_header();
+  TLOG() << "First: " << h5_raw_data_file.get_frag_ptr(first_trig_num, 0, "TPC", 0, 0)->get_header();
   TLOG() << "Last: " << h5_raw_data_file.get_frag_ptr(all_frag_paths.back())->get_header();
 
   return 0;

--- a/unittest/HDF5WriteRead_test.cxx
+++ b/unittest/HDF5WriteRead_test.cxx
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE(ReadFileDatasets)
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(),run_number);
   
   //test access by trigger number, type, region, element
-  frag_ptr = h5file_ptr->get_frag_ptr(2,"TPC",1,0);
+  frag_ptr = h5file_ptr->get_frag_ptr(2,0,"TPC",1,0);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(),2);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(),run_number);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_element_id().system_type,
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(ReadFileDatasets)
   BOOST_REQUIRE_EQUAL(frag_ptr->get_element_id().element_id,0);
 
   //test access by trigger number, type, region, element
-  frag_ptr = h5file_ptr->get_frag_ptr(4,"PDS",0,1);
+  frag_ptr = h5file_ptr->get_frag_ptr(4,0,"PDS",0,1);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(),4);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(),run_number);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_element_id().system_type,
@@ -331,7 +331,7 @@ BOOST_AUTO_TEST_CASE(ReadFileDatasets)
 
   //test access by passing in GeoID
   dunedaq::daqdataformats::GeoID gid = {dunedaq::daqdataformats::GeoID::SystemType::kPDS,1,1};
-  frag_ptr = h5file_ptr->get_frag_ptr(5,gid);
+  frag_ptr = h5file_ptr->get_frag_ptr(5,0,gid);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(),5);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(),run_number);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_element_id().system_type,
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE(ReadFileMaxSequence)
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(),run_number);
   
   //test access by trigger number, type, region, element
-  frag_ptr = h5file_ptr->get_frag_ptr(2,"TPC",1,0);
+  frag_ptr = h5file_ptr->get_frag_ptr(2,0,"TPC",1,0);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(),2);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(),run_number);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_element_id().system_type,
@@ -420,7 +420,7 @@ BOOST_AUTO_TEST_CASE(ReadFileMaxSequence)
   BOOST_REQUIRE_EQUAL(frag_ptr->get_element_id().element_id,0);
 
   //test access by trigger number, type, region, element
-  frag_ptr = h5file_ptr->get_frag_ptr(4,"PDS",0,1);
+  frag_ptr = h5file_ptr->get_frag_ptr(4,0,"PDS",0,1);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(),4);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(),run_number);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_element_id().system_type,
@@ -430,7 +430,7 @@ BOOST_AUTO_TEST_CASE(ReadFileMaxSequence)
 
   //test access by passing in GeoID
   dunedaq::daqdataformats::GeoID gid = {dunedaq::daqdataformats::GeoID::SystemType::kPDS,1,1};
-  frag_ptr = h5file_ptr->get_frag_ptr(5,gid);
+  frag_ptr = h5file_ptr->get_frag_ptr(5,0,gid);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(),5);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(),run_number);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_element_id().system_type,


### PR DESCRIPTION
Fixes #13.

Disallows `digits_for_sequence_number` to be 0 for anything in version 2 or beyond. 

Fixes #14.

Adds a fast lookup for number of digits in path name comparisons, and adds warning messages and handling of those cases.