### PR TITLE
Dingpf/update hdf5 dump output with sequence number

### DIFF
--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -88,19 +88,21 @@ class DAQDataFile:
                 dset = self.h5file[i.header]
                 data_array = bytearray(dset[:])
                 (h, j, k) = struct.unpack('<3Q', data_array[8:32])
+                s = struct.unpack('<H', data_array[42:44])
                 nf = len(i.fragments)
-                report.append((h, k, nf, nf - k))
+                report.append((h, s, k, nf, nf - k))
                 n += 1
-            print("{:-^60}".format("Column Definitions"))
+            print("{:-^80}".format("Column Definitions"))
             print("i:           Trigger record number;")
+            print("s:           Sequence number;")
             print("N_frag_exp:  expected no. of fragments stored in header;")
             print("N_frag_act:  no. of fragments written in trigger record;")
             print("N_diff:      N_frag_act - N_frag_exp")
-            print("{:-^60}".format("Column Definitions"))
-            print("{:^10}{:^15}{:^15}{:^10}".format(
-                "i", "N_frag_exp", "N_frag_act", "N_diff"))
+            print("{:-^80}".format("Column Definitions"))
+            print("{:^10}{:^10}{:^15}{:^15}{:^10}".format(
+                "i", "s", "N_frag_exp", "N_frag_act", "N_diff"))
             for i in range(len(report)):
-                print("{:^10}{:^15}{:^15}{:^10}".format(*report[i]))
+                print("{:^10}{:^10}{:^15}{:^15}{:^10}".format(*report[i]))
         return
 
     class Record:

--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -88,7 +88,7 @@ class DAQDataFile:
                 dset = self.h5file[i.header]
                 data_array = bytearray(dset[:])
                 (h, j, k) = struct.unpack('<3Q', data_array[8:32])
-                s = struct.unpack('<H', data_array[42:44])
+                (s, ) = struct.unpack('<H', data_array[42:44])
                 nf = len(i.fragments)
                 report.append((h, s, k, nf, nf - k))
                 n += 1


### PR DESCRIPTION
The output of the check-fragment report now has a column of the sequence number stored in the trigger record header.

It looks like the following: 

```
$ hdf5_dump.py -f sourcecode/hdf5libs/swtest.hdf5 -c -p all -n 3
...
-------------------------------Column Definitions-------------------------------
i:           Trigger record number;
s:           Sequence number;
N_frag_exp:  expected no. of fragments stored in header;
N_frag_act:  no. of fragments written in trigger record;
N_diff:      N_frag_act - N_frag_exp
-------------------------------Column Definitions-------------------------------
    i         s       N_frag_exp     N_frag_act     N_diff
    1         0            2              2           0
    2         0            2              2           0
    3         0            2              2           0
```

This is to address the issue in DUNE-DAQ/dfmodules#194.