### PR TITLE
adding support for new HDF5 format with SourceID in hdf5_dump.py

### DIFF
--- a/scripts/binary_dump.py
+++ b/scripts/binary_dump.py
@@ -101,7 +101,7 @@ def parse_args():
                         default=0)
 
     parser.add_argument('-s', '--speed-of-clock', type=float,
-                        help='''specify clock spped in Hz, default is
+                        help='''specify clock speed in Hz, default is
                         50000000.0 (50MHz)''',
                         default=50000000.0)
 

--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -4,12 +4,67 @@ import argparse
 import datetime
 import h5py
 import struct
+import os
+import sys
+
+
+# detdataformats/include/detdataformats/DetID.hpp
+DETECTOR = {0: 'Unknown', 1: 'DAQ', 2: 'HD_PDS', 3: 'HD_TPC',
+            4: 'HD_CRT', 8: 'VD_CathodePDS', 9: 'VD_MembranePDS',
+            10: 'VD_BottomTPC', 11: 'VD_TopTPC',
+            32: 'ND_LAr', 33: 'ND_GAr'}
+
+# daqdataformats/include/daqdataformats/SourceID.hpp
+SUBSYSTEM = {0: 'Unknown', 1: 'DetectorReadout', 2: 'HwSignalsInterface',
+             3: 'Trigger', 4: 'TRBuilder'}
+
+DATA_FORMAT = {
+    # daqdataformats/include/daqdataformats/TimeSliceHeader.hpp
+    "TimeSlice Header": {
+        "keys": ['Marker word', 'Version', 'TimeSlice number',                     # I I Q
+                 'Run number', "Padding",                                          # I I
+                 'Source ID version', 'Source ID subsystem', 'Source ID'],         # H H I
+        "size": 32,
+        "unpack string": '<2IQ2I2HI'
+    },
+    # daqdataformats/include/daqdataformats/TriggerRecordHeaderData.hpp
+    "TriggerRecord Header": {
+        "keys": ['Marker word', 'Version', 'Trigger number',                       # I I Q
+                 'Trigger timestamp', 'No. of requested components', 'Run number', # Q Q I
+                 'Error bits', 'Trigger type', 'Sequence number',                  # I H H
+                 'Max sequence num', 'Padding',                                    # H H
+                 'Source ID version', 'Source ID subsystem', 'Source ID'],         # H H I
+        "size": 56,
+        "unpack string": '<2I3Q2I6HI'
+    },
+    # daqdataformats/include/daqdataformats/FragmentHeader.hpp
+    "Fragment Header":{
+        "keys": ['Marker word', 'Version', 'Fragment zize', 'Trigger number',      # I I Q Q
+                 'Trigger timestamp', 'Window begin', 'Window end', 'Run number',  # Q Q Q I
+                 'Error bits', 'Fragment type', 'Sequence number',                 # I I H
+                 'Detector',                                                       # H
+                 'Source ID version', 'Source ID subsystem', 'Source ID'],         # H H I
+        "size": 72,
+        "unpack string": '<2I5Q3I4HI'
+    },
+    # daqdataformats/include/daqdataformats/ComponentRequest.hpp
+    "Component Request":{
+        "keys": ['Component request version', 'Padding',                           # I I
+                 'Source ID version', 'Source ID subsystem', 'Source ID',          # H H I
+                 'Begin time', 'End time'],                                        # Q Q
+        "size": 32,
+        "unpack string": "<2I2HI2Q"
+    }
+}
 
 
 class DAQDataFile:
     def __init__(self, name):
         self.name = name
-        self.h5file = h5py.File(self.name, 'r')
+        if os.path.exists(self.name):
+            self.h5file = h5py.File(self.name, 'r')
+        else:
+            sys.exit(f"ERROR: HDF5 file {self.name} is not found!")
         # Assume HDf5 files without file attributes field "record_type"
         # are old data files which only contain "TriggerRecord" data.
         self.record_type = 'TriggerRecord'
@@ -48,17 +103,24 @@ class DAQDataFile:
     def printout(self, k_header_type, k_nrecords, k_list_components=False):
         k_header_type = set(k_header_type)
         if not {"attributes", "all"}.isdisjoint(k_header_type):
-            print(32*"=", "File  Metadata", 32*"=")
+            banner_str = " File Attributes "
+            print(banner_str.center(80, '='))
             for k in self.h5file.attrs.keys():
                 print("{:<30}: {}".format(k, self.h5file.attrs[k]))
         n = 0
         for i in self.records:
             if n >= k_nrecords and k_nrecords > 0:
                 break
+            if not {"attributes", "all"}.isdisjoint(k_header_type):
+                banner_str = " Trigger Record Attributes "
+                print(banner_str.center(80, '='))
+                for k in self.h5file[i.path].attrs.keys():
+                    print("{:<30}: {}".format(k, self.h5file[i.path].attrs[k]))
             if not {"header", "both", "all"}.isdisjoint(k_header_type):
                 dset = self.h5file[i.header]
                 data_array = bytearray(dset[:])
-                print(24*"=", "TriggerRecord/TimeSlice Header", 24*"=")
+                banner_str = f" {self.record_type} Header "
+                print(banner_str.center(80, '='))
                 print('{:<30}:\t{}'.format("Path", i.path))
                 print('{:<30}:\t{}'.format("Size", dset.shape))
                 print('{:<30}:\t{}'.format("Data type", dset.dtype))
@@ -68,7 +130,8 @@ class DAQDataFile:
                 for j in i.fragments:
                     dset = self.h5file[j]
                     data_array = bytearray(dset[:])
-                    print(31*"-", "Fragment Header ", 31*"-")
+                    banner_str = " Fragment Header "
+                    print(banner_str.center(80, '-'))
                     print('{:<30}:\t{}'.format("Path", j))
                     print('{:<30}:\t{}'.format("Size", dset.shape))
                     print('{:<30}:\t{}'.format("Data type", dset.dtype))
@@ -113,7 +176,7 @@ class DAQDataFile:
 
         def __call__(self, name, dset):
             if isinstance(dset, h5py.Dataset):
-                if "Header" in name:
+                if "TR_Builder" in name:
                     self.header = self.path + '/' + name
                     # set ncomponents here
                 else:
@@ -128,22 +191,15 @@ def tick_to_timestamp(ticks, clock_speed_hz):
         return "InvalidDateString"
 
 
-def unpack_header(data_array, unpack_string, keys):
-    values = struct.unpack(unpack_string, data_array)
-    header = dict(zip(keys, values))
+def unpack_header(data_array, entry_type):
+    values = struct.unpack(DATA_FORMAT[entry_type]["unpack string"],
+                           data_array[:DATA_FORMAT[entry_type]["size"]])
+    header = dict(zip(DATA_FORMAT[entry_type]["keys"], values))
     return header
 
 
-def get_geo_id_type(i):
-    types = {1: 'TPC', 2: 'PDS', 3: 'DataSelection', 4: 'NDLArTPC'}
-    if i in types.keys():
-        return types[i]
-    else:
-        return "Invalid"
-
-
 def print_header_dict(hdict, clock_speed_hz):
-    filtered_list = ['Padding', 'GeoID version', 'Component request version']
+    filtered_list = ['Padding', 'Source ID version', 'Component request version']
     for ik, iv in hdict.items():
         if any(map(ik.__contains__, filtered_list)):
             continue
@@ -152,54 +208,30 @@ def print_header_dict(hdict, clock_speed_hz):
                 ik, iv, tick_to_timestamp(iv, clock_speed_hz)))
         elif 'Marker word' in ik:
             print("{:<30}: {}".format(ik, hex(iv)))
-        elif 'GeoID type' in ik:
-            print("{:<30}: {}".format(ik, get_geo_id_type(iv)))
+        elif ik == 'Detector':
+            print("{:<30}: {}".format(ik, DETECTOR[iv]))
+        elif ik == 'Source ID subsystem' in ik:
+            print("{:<30}: {}".format(ik, SUBSYSTEM[iv]))
         else:
             print("{:<30}: {}".format(ik, iv))
     return
 
 
-def print_fragment_header(data_array, clock_speed_hz):
-    keys = ['Marker word', 'Version', 'Frag Size', 'Trig number',
-            'Trig timestamp', 'Window begin', 'Window end', 'Run number',
-            'Error bits', 'Fragment type', 'Sequence number',
-            'Fragment Padding', 'GeoID version', 'GeoID type', 'GeoID region',
-            'GeoID element', 'Geo ID Padding']
-    unpack_string = '<2I5Q3I2H1I2H2I'
-    print_header_dict(unpack_header(data_array[:80], unpack_string, keys),
-                      clock_speed_hz)
-    return
-
-
 def print_trigger_record_header(data_array, clock_speed_hz, k_list_components):
-    keys = ['Marker word', 'Version', 'Trigger number',
-            'Trigger timestamp', 'No. of requested components', 'Run Number',
-            'Error bits', 'Trigger type', 'Sequence number',
-            'Max sequence num']
-    unpack_string = '<2I3Q2I3H'
-    print_header_dict(unpack_header(data_array[:46], unpack_string, keys),
-                      clock_speed_hz)
+    print_header_dict(unpack_header(data_array, "TriggerRecord Header"), clock_speed_hz)
 
     if k_list_components:
-        comp_keys = ['Component request version', 'Component Request Padding',
-                     'GeoID version', 'GeoID type', 'GeoID region',
-                     'GeoID element', 'Geo ID Padding', 'Begin time',
-                     'End time']
-        comp_unpack_string = "<3I2H2I2Q"
-        for i_values in struct.iter_unpack(comp_unpack_string,
-                                           data_array[48:]):
+        comp_keys = DATA_FORMAT["Component Request"]["keys"]
+        comp_unpack_string = DATA_FORMAT["Component Request"]["unpack string"]
+        for i_values in struct.iter_unpack(comp_unpack_string, data_array[56:]):
             i_comp = dict(zip(comp_keys, i_values))
             print(80*'-')
             print_header_dict(i_comp, clock_speed_hz)
     return
 
 
-def print_time_slice_header(data_array, clock_speed_hz):
-    keys = ['Marker word', 'Version', 'TimeSlice number',
-            'Run number']
-    unpack_string = '<2IQI'
-    print_header_dict(unpack_header(data_array[:20], unpack_string, keys),
-                      clock_speed_hz)
+def print_fragment_header(data_array, clock_speed_hz):
+    print_header_dict(unpack_header(data_array, "Fragment Header"), clock_speed_hz)
     return
 
 
@@ -208,7 +240,7 @@ def print_header(data_array, record_type, clock_speed_hz, k_list_components):
         print_trigger_record_header(data_array, clock_speed_hz,
                                     k_list_components)
     elif record_type == "TimeSlice":
-        print_time_slice_header(data_array, clock_speed_hz)
+        print_header_dict(unpack_header(data_array, "TimeSlice Header"), clock_speed_hz)
     else:
         print(f"Error: Record Type {record_type} is not supported.")
     return
@@ -253,7 +285,7 @@ def parse_args():
                         default=50000000.0)
 
     parser.add_argument('-v', '--version', action='version',
-                        version='%(prog)s 1.0')
+                        version='%(prog)s 2.0')
     return parser.parse_args()
 
 

--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -8,6 +8,7 @@ import os
 import sys
 
 
+FILELAYOUT_VERSION = 3
 # detdataformats/include/detdataformats/DetID.hpp
 DETECTOR = {0: 'Unknown', 1: 'DAQ', 2: 'HD_PDS', 3: 'HD_TPC',
             4: 'HD_CRT', 8: 'VD_CathodePDS', 9: 'VD_MembranePDS',
@@ -70,6 +71,11 @@ class DAQDataFile:
         self.record_type = 'TriggerRecord'
         self.clock_speed_hz = 50000000.0
         self.records = []
+        if 'filelayout_version' in self.h5file.attrs.keys() and \
+                self.h5file.attrs['filelayout_version'] == FILELAYOUT_VERSION:
+            print(f"INFO: input file matches the supported file layout version: {FILELAYOUT_VERSION}")
+        else:
+            sys.exit(f"ERROR: HDF5 file {self.name} with file layout version {FILELAYOUT_VERSION} is not supported!")
         if 'record_type' in self.h5file.attrs.keys():
             self.record_type = self.h5file.attrs['record_type']
         for i in self.h5file.keys():


### PR DESCRIPTION
This update includes support for:
1. the new `SourceID` object;
2. printint out attributes stored with each trigger record.

Code-wise, this update has the following changes:
1. gathered data format definitions into a dictionary at the top of the script, which contains items for classes defined in `dataformats`, such as `TimeSlice Header`, `TriggerRecord Header`, `Fragment Header`, `Component Request`;
2. Added check on the existence of input file.

The command-line interface remains unchanged. I've tested the script with both `TriggerRecord` and `TimeSlice` data files. The tests I did are:

1. `./hdf5_dump.py -f <InputFile> -p all -l -c`
2. `./hdf5_dump.py -f <InputFile> -p header -n 1`
3. `./hdf5_dump.py -f <InputFile> -p both -n 1`
4. `./hdf5_dump.py -f <InputFile> -p attributes -n 1`
5. `./hdf5_dump.py -f <InputFile> -b test.bin`
6. `./binary_dump.py -f test.bin -p both -n 1`

