### PR TITLE
Added methods for fetching the geo IDs for a given record ID and subdetector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-project(hdf5libs VERSION 2.3.0)
+project(hdf5libs VERSION 2.3.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -243,6 +243,26 @@ public:
   {
     return get_geo_ids(std::make_pair(rec_num, seq_num));
   }
+  std::set<uint64_t> get_geo_ids_for_subdetector(const record_id_t& rid, // NOLINT(build/unsigned)
+                                                 const detdataformats::DetID::Subdetector subdet);
+  std::set<uint64_t> get_geo_ids_for_subdetector(const uint64_t rec_num, //NOLINT(build/unsigned)
+                                                 const daqdataformats::sequence_number_t seq_num,
+                                                 const detdataformats::DetID::Subdetector subdet)
+  {
+    return get_geo_ids_for_subdetector(std::make_pair(rec_num, seq_num), subdet);
+  }
+  std::set<uint64_t> get_geo_ids_for_subdetector(const record_id_t& rid, // NOLINT(build/unsigned)
+                                                 const std::string& subdet_name)
+  {
+    detdataformats::DetID::Subdetector subdet = detdataformats::DetID::string_to_subdetector(subdet_name);
+    return get_geo_ids_for_subdetector(rid, subdet);
+  }
+  std::set<uint64_t> get_geo_ids_for_subdetector(const uint64_t rec_num, //NOLINT(build/unsigned)
+                                                 const daqdataformats::sequence_number_t seq_num,
+                                                 const std::string& subdet_name)
+  {
+    return get_geo_ids_for_subdetector(std::make_pair(rec_num, seq_num), subdet_name);
+  }
 
   // get SourceIDs in a record
   std::set<daqdataformats::SourceID> get_source_ids(const record_id_t& rid);

--- a/pybindsrc/hdf5rawdatafile.cpp
+++ b/pybindsrc/hdf5rawdatafile.cpp
@@ -131,6 +131,10 @@ register_hdf5rawdatafile(py::module& m)
          py::overload_cast<const uint64_t,const daqdataformats::sequence_number_t> //NOLINT(build/unsigned)
          (&HDF5RawDataFile::get_geo_ids),
          "Get all GeoIDs in a record/sequence number")
+    .def("get_geo_ids_for_subdetector",
+         py::overload_cast<const HDF5RawDataFile::record_id_t&,const detdataformats::DetID::Subdetector>
+         (&HDF5RawDataFile::get_geo_ids_for_subdetector),
+         "Get all GeoIDs in a record id with the specified Subdetector type")
     .def("get_source_ids",
          py::overload_cast<const HDF5RawDataFile::record_id_t&>
          (&HDF5RawDataFile::get_source_ids),


### PR DESCRIPTION
Also removed std::move calls in return statements as suggested by compiler warnings.

This is part of getting the wib2decoder.py script in the rawdatautils repo to work again.