### PR TITLE
Switched to using std::cout for some of the output from HDF5LIBS_TestDumpRecord

### DIFF
--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -98,10 +98,13 @@ main(int argc, char** argv)
     }
     TLOG() << ss.str();
     ss.str("");
+    bool first_frag = true;
     std::set<SourceID> frag_sid_list = h5_raw_data_file.get_fragment_source_ids(record_id);
     for (auto const& source_id : frag_sid_list) {
+      if (first_frag) {first_frag = false;}
+      else {ss << "\n";}
       auto frag_ptr = h5_raw_data_file.get_frag_ptr(record_id, source_id);
-      ss << "\n\t" << fragment_type_to_string(frag_ptr->get_fragment_type()) << " fragment with SourceID "
+      ss << "\t" << fragment_type_to_string(frag_ptr->get_fragment_type()) << " fragment with SourceID "
          << frag_ptr->get_element_id().to_string() << " from subdetector "
          << DetID::subdetector_to_string(static_cast<DetID::Subdetector>(frag_ptr->get_detector_id()))
          << " has size = " << frag_ptr->get_size();

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -96,6 +96,8 @@ main(int argc, char** argv)
       auto trh_ptr = h5_raw_data_file.get_trh_ptr(record_id);
       ss << "\n\tTriggerRecordHeader: " << trh_ptr->get_header();
     }
+    TLOG() << ss.str();
+    ss.str("");
     std::set<SourceID> frag_sid_list = h5_raw_data_file.get_fragment_source_ids(record_id);
     for (auto const& source_id : frag_sid_list) {
       auto frag_ptr = h5_raw_data_file.get_frag_ptr(record_id, source_id);
@@ -115,7 +117,7 @@ main(int argc, char** argv)
         }
       }
     }
-    TLOG() << ss.str();
+    std::cout << ss.str() << std::endl;
     ss.str("");
   }
 


### PR DESCRIPTION
 ...to avoid filling up the ers or trace buffer.

When looking at some of the raw data files created during the integration week (e.g. /data2/np04_hd_run017981_0005_dataflow0_datawriter_0_20221117T151934.hdf5.copied), I noticed that the HDF5LIBS_TestDumpRecord utility was not providing information on all of the Fragments within each TriggerRecord (some of the Fragments seemed to be missing).  

After some debugging, my theory is that some buffer in ers or trace has a maximum size of 8192, and that is why we are seeing truncated output (the HDF5LIBS_TestDumpRecord app uses TLOG() messages).

Instead of getting into a search of which library is imposing this limit and figuring out how to increase it, I simply modified HDF5LIBS_TestDumpRecord to use std::cout for the larger fraction of each message. 

This seems to be in line with what other "dump" utilities are doing (e.g. trigger/test/apps/print_ds_fragments.cxx uses std::cout).