### PR TITLE
Changed clock frequency defaults to 62.5 MHz

### DIFF
--- a/scripts/binary_dump.py
+++ b/scripts/binary_dump.py
@@ -102,8 +102,8 @@ def parse_args():
 
     parser.add_argument('-s', '--speed-of-clock', type=float,
                         help='''specify clock speed in Hz, default is
-                        50000000.0 (50MHz)''',
-                        default=50000000.0)
+                        62500000.0 (62.5MHz)''',
+                        default=62500000.0)
 
     parser.add_argument('-v', '--version', action='version',
                         version='%(prog)s 1.0')

--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -72,7 +72,7 @@ class DAQDataFile:
         # Assume HDf5 files without file attributes field "record_type"
         # are old data files which only contain "TriggerRecord" data.
         self.record_type = 'TriggerRecord'
-        self.clock_speed_hz = 62500000.0
+        self.clock_speed_hz = 50000000.0
         self.records = []
         if 'filelayout_version' in self.h5file.attrs.keys() and \
                 self.h5file.attrs['filelayout_version'] == FILELAYOUT_VERSION:

--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -72,7 +72,7 @@ class DAQDataFile:
         # Assume HDf5 files without file attributes field "record_type"
         # are old data files which only contain "TriggerRecord" data.
         self.record_type = 'TriggerRecord'
-        self.clock_speed_hz = 50000000.0
+        self.clock_speed_hz = 62500000.0
         self.records = []
         if 'filelayout_version' in self.h5file.attrs.keys() and \
                 self.h5file.attrs['filelayout_version'] == FILELAYOUT_VERSION:
@@ -293,8 +293,8 @@ def parse_args():
 
     parser.add_argument('-s', '--speed-of-clock', type=float,
                         help='''specify clock speed in Hz, default is
-                        50000000.0 (50MHz)''',
-                        default=50000000.0)
+                        62500000.0 (62.5MHz)''',
+                        default=62500000.0)
 
     parser.add_argument('-v', '--version', action='version',
                         version='%(prog)s 2.0')


### PR DESCRIPTION
The full set of repositories that are affected by this change is contained in the following list

```
git clone https://github.com/DUNE-DAQ/daqconf.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dqm.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/flxlibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hdf5libs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hsilibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/readoutmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/timinglibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/trigger.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/triggeralgs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/wibmod.git -b kbiery/62.5MHz_defaults
```

Recall that this first step in the deprecation of legacy hardware is simply switching to a default clock frequency of 62.5 MHz in our scripts, etc.  More changes will come later.