### PR TITLE
Add capability to rebuild the source id  - geo id map

### DIFF
--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -146,7 +146,7 @@ public:
   bool is_trigger_record_type() const noexcept { return m_record_type.compare("TriggerRecord") == 0; }
   bool is_timeslice_type() const noexcept { return m_record_type.compare("TimeSlice") == 0; }
 
-  HDF5FileLayout get_file_layout() const { return *(m_file_layout_ptr.get()); }
+  const HDF5FileLayout& get_file_layout() const { return *(m_file_layout_ptr.get()); }
 
   uint32_t get_version() const // NOLINT(build/unsigned)
   {
@@ -233,8 +233,10 @@ public:
   std::set<daqdataformats::SourceID> get_source_ids(std::vector<std::string> const& frag_dataset_paths);
 #endif
 
+  hdf5rawdatafile::SrcIDGeoIDMap get_srcid_geoid_map() const;
+
   //get a list of all the geo ids anywhere in the file
-  std::set<uint64_t> get_all_geo_ids(); // NOLINT(build/unsigned)
+  std::set<uint64_t> get_all_geo_ids() const; // NOLINT(build/unsigned)
 
   //get GeoIDs in a record
   std::set<uint64_t> get_geo_ids(const record_id_t& rid); // NOLINT(build/unsigned)

--- a/include/hdf5libs/HDF5SourceIDHandler.hpp
+++ b/include/hdf5libs/HDF5SourceIDHandler.hpp
@@ -57,6 +57,11 @@ public:
    */
   static void populate_source_id_geo_id_map(dunedaq::hdf5libs::hdf5rawdatafile::SrcIDGeoIDMap  src_id_geo_id_mp_struct,
                                             source_id_geo_id_map_t& the_map);
+
+  /**
+   * Reconstruct the SrcIDGeoIDMap
+  */
+  static hdf5rawdatafile::SrcIDGeoIDMap rebuild_srcidgeoidmap(const source_id_geo_id_map_t& the_map);
   /**
    * Stores the map from SourceID to GeoID in the specified HighFive::File.
    */

--- a/schema/hdf5libs/hdf5sourceidmaps.jsonnet
+++ b/schema/hdf5libs/hdf5sourceidmaps.jsonnet
@@ -36,7 +36,7 @@ local types = {
         s.field("subsys", self.numeric_value, 0, doc="SourceID subsystem"),
         s.field("id", self.numeric_value, 0, doc="SourceID ID"),
         s.field("geoids", self.list_of_geo_ids, doc="List of GeoIDs contained within the SourceID")
-    ], doc="A single SourceID-to-HDF5-path map entry"),
+    ], doc="A single SourceID-to-GeoID map entry"),
 
     list_of_geo_id_map_entries : s.sequence("GeoIDMapEntryList", self.source_id_geo_id_pair, doc="List of SourceID to GeoID map entries"),
 

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -814,8 +814,14 @@ HDF5RawDataFile::get_source_ids(std::vector<std::string> const& frag_dataset_pat
 }
 #endif
 
+hdf5rawdatafile::SrcIDGeoIDMap
+HDF5RawDataFile::get_srcid_geoid_map() const {
+
+  return HDF5SourceIDHandler::rebuild_srcidgeoidmap(m_file_level_source_id_geo_id_map);
+}
+
 std::set<uint64_t> // NOLINT(build/unsigned)
-HDF5RawDataFile::get_all_geo_ids()
+HDF5RawDataFile::get_all_geo_ids() const
 {
   std::set<uint64_t> set_of_geo_ids;
   // 13-Sep-2022, KAB

--- a/src/HDF5SourceIDHandler.cpp
+++ b/src/HDF5SourceIDHandler.cpp
@@ -32,18 +32,17 @@ HDF5SourceIDHandler::rebuild_srcidgeoidmap(const source_id_geo_id_map_t& the_map
 
   hdf5rawdatafile::SrcIDGeoIDMap m;
   for( const auto& [sid, geoids] : the_map ) {
-
-    // There could be more than one, but we don't want to think about that
-    uint64_t geoid = *geoids.begin();
-    m.emplace_back(hdf5rawdatafile::SrcIDGeoIDEntry{
-      sid.id, 
-      hdf5rawdatafile::GeoID{
-        (geoid >> 48) && 0xff,
-        (geoid >> 32) && 0xff,
-        (geoid >> 16) && 0xff,
-        (geoid >> 0) && 0xff,
+      // There could be more than one, but we don't want to think about that
+      uint64_t geoid = *geoids.begin();
+      m.emplace_back(hdf5rawdatafile::SrcIDGeoIDEntry{
+        sid.id, 
+        hdf5rawdatafile::GeoID{
+          .det_id = (geoid >> 0) & 0xff,
+          .crate_id = (geoid >> 16) & 0xff,
+          .slot_id = (geoid >> 32) & 0xff,
+          .stream_id = (geoid >> 48) & 0xff,
+        }
       }
-    }
     );
   } 
 

--- a/src/HDF5SourceIDHandler.cpp
+++ b/src/HDF5SourceIDHandler.cpp
@@ -27,6 +27,29 @@ HDF5SourceIDHandler::populate_source_id_geo_id_map(dunedaq::hdf5libs::hdf5rawdat
   }
 }
 
+hdf5rawdatafile::SrcIDGeoIDMap
+HDF5SourceIDHandler::rebuild_srcidgeoidmap(const source_id_geo_id_map_t& the_map) {
+
+  hdf5rawdatafile::SrcIDGeoIDMap m;
+  for( const auto& [sid, geoids] : the_map ) {
+
+    // There could be more than one, but we don't want to think about that
+    uint64_t geoid = *geoids.begin();
+    m.emplace_back(hdf5rawdatafile::SrcIDGeoIDEntry{
+      sid.id, 
+      hdf5rawdatafile::GeoID{
+        (geoid >> 48) && 0xff,
+        (geoid >> 32) && 0xff,
+        (geoid >> 16) && 0xff,
+        (geoid >> 0) && 0xff,
+      }
+    }
+    );
+  } 
+
+  return m;
+}
+
 void
 HDF5SourceIDHandler::store_file_level_geo_id_info(HighFive::File& h5_file, const source_id_geo_id_map_t& the_map)
 {


### PR DESCRIPTION
In some usecases, mostly related to trigger emulation, it would be very useful to be able to re-create (or copy) a raw data file  record by record. In order to do that, having access to the argument used to create the original raw data file is necessary.
It turns out that most of the arguments of the `HDF5RawDataFile` constructor required to create an empty file identical to the original are recoverable with the current `HDF5RawDataFile` interface, with the notable exception of `                  hdf5rawdatafile::SrcIDGeoIDMap srcid_geoid_map`.

This PR is a demonstration of how one could recover the `hdf5rawdatafile::SrcIDGeoIDMap` from the `m_file_level_source_id_geo_id_map` `HDF5RawDataFile` data member. Better solutions probably exists.
The purpose of this PR is to illustrate the problem first, and maybe provide a stopgap solution.
