### PR TITLE
Added printout of information in HDF5LIBS_TestDumpRecord

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(ers REQUIRED)
 find_package(HighFive REQUIRED)
 find_package(daqdataformats REQUIRED)
 find_package(detdataformats REQUIRED)
+find_package(trgdataformats REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(Boost COMPONENTS iostreams unit_test_framework REQUIRED)
 
@@ -17,7 +18,7 @@ daq_codegen( *.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 
 ##############################################################################
 # Main library
-daq_add_library (HDF5FileLayout.cpp HDF5SourceIDHandler.cpp HDF5RawDataFile.cpp LINK_LIBRARIES stdc++fs ers::ers HighFive daqdataformats::daqdataformats detdataformats::detdataformats logging::logging nlohmann_json::nlohmann_json)
+daq_add_library (HDF5FileLayout.cpp HDF5SourceIDHandler.cpp HDF5RawDataFile.cpp LINK_LIBRARIES stdc++fs ers::ers HighFive daqdataformats::daqdataformats detdataformats::detdataformats trgdataformats::trgdataformats logging::logging nlohmann_json::nlohmann_json)
 
 ##############################################################################
 # Unit tests

--- a/cmake/hdf5libsConfig.cmake.in
+++ b/cmake/hdf5libsConfig.cmake.in
@@ -7,6 +7,7 @@ find_dependency(ers)
 find_dependency(HighFive)
 find_dependency(daqdataformats)
 find_dependency(detdataformats)
+find_dependency(trgdataformats)
 find_dependency(cetlib)
 
 # Figure out whether or not this dependency is an installed package or

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -136,11 +136,17 @@ main(int argc, char** argv)
         ss << "\n\t\t" << "Start time = " << tcptr->data.time_start << ", end time = " << tcptr->data.time_end
            << ", and candidate time = " << tcptr->data.time_candidate;
       }
-      auto trh_ptr = h5_raw_data_file.get_trh_ptr(record_id);
-      ComponentRequest cr = trh_ptr->get_component_for_source_id(frag_ptr->get_element_id());
-      ss << "\n\t\t"
-         << "Readout window before = " << (trh_ptr->get_trigger_timestamp()-cr.window_begin)
-         << ", after = " << (cr.window_end-trh_ptr->get_trigger_timestamp());
+      try {
+        auto trh_ptr = h5_raw_data_file.get_trh_ptr(record_id);
+        ComponentRequest cr = trh_ptr->get_component_for_source_id(frag_ptr->get_element_id());
+        ss << "\n\t\t"
+           << "Readout window before = " << (trh_ptr->get_trigger_timestamp()-cr.window_begin)
+           << ", after = " << (cr.window_end-trh_ptr->get_trigger_timestamp());
+      }
+      catch (std::exception const& excpt) {
+        ss << "\n\t\t"
+           << "Unable to determine readout window, exception was \"" << excpt.what() << "\"";
+      }
     }
     std::cout << ss.str() << std::endl;
     ss.str("");

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -11,10 +11,12 @@
 
 #include "hdf5libs/HDF5RawDataFile.hpp"
 
+#include "daqdataformats/Fragment.hpp"
 #include "detdataformats/DetID.hpp"
 #include "logging/Logging.hpp"
 #include "hdf5libs/hdf5rawdatafile/Structs.hpp"
 #include "hdf5libs/hdf5rawdatafile/Nljs.hpp"
+#include "trgdataformats/TriggerObjectOverlay.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -24,6 +26,7 @@
 using namespace dunedaq::hdf5libs;
 using namespace dunedaq::daqdataformats;
 using namespace dunedaq::detdataformats;
+using namespace dunedaq::trgdataformats;
 
 void
 print_usage()
@@ -125,6 +128,19 @@ main(int argc, char** argv)
              << ", crate " << crate_id << ", slot " << slot_id << ", link " << link_id;
         }
       }
+      if (frag_ptr->get_fragment_type() == FragmentType::kTriggerCandidate) {
+        TriggerCandidate* tcptr = static_cast<TriggerCandidate*>(frag_ptr->get_data());
+        ss << "\n\t\t" << "TC type = " << get_trigger_candidate_type_names()[tcptr->data.type]
+           << " (" << static_cast<int>(tcptr->data.type) << "), TC algorithm = "
+           << static_cast<int>(tcptr->data.algorithm) << ", number of TAs = " << tcptr->n_inputs;
+        ss << "\n\t\t" << "Start time = " << tcptr->data.time_start << ", end time = " << tcptr->data.time_end
+           << ", and candidate time = " << tcptr->data.time_candidate;
+      }
+      auto trh_ptr = h5_raw_data_file.get_trh_ptr(record_id);
+      ComponentRequest cr = trh_ptr->get_component_for_source_id(frag_ptr->get_element_id());
+      ss << "\n\t\t"
+         << "Readout window before = " << (trh_ptr->get_trigger_timestamp()-cr.window_begin)
+         << ", after = " << (cr.window_end-trh_ptr->get_trigger_timestamp());
     }
     std::cout << ss.str() << std::endl;
     ss.str("");


### PR DESCRIPTION
The new information includes details from TriggerCandidate fragments and ComponentRequest lists.

I found these additions useful when testing the MLT readout map rework.  In those tests, I had multiple types of TriggerCandidates being generated, and different sizes for readout windows for different TC types.

The changes in this PR depend on ones in [daqdataformats PR 50](https://github.com/DUNE-DAQ/daqdataformats/pull/50).
