### PR TITLE
HDF5 Attributes for Python

### DIFF
--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -174,6 +174,7 @@ public:
   template<typename T>
   void write_attribute(HighFive::DataSet& dset, const std::string& name, T value);
 
+  std::vector<std::string> get_attribute_names();
   template<typename T>
   T get_attribute(const std::string& name);
   template<typename T>
@@ -504,6 +505,12 @@ HDF5RawDataFile::write_attribute(HighFive::DataSet& dset, const std::string& nam
   else
     ers::warning(HDF5AttributeExists(ERS_HERE, name));
 }
+
+std::vector<std::string> HDF5RawDataFile::get_attribute_names()
+{
+  return m_file_ptr->listAttributeNames();
+}
+
 template<typename T>
 T
 HDF5RawDataFile::get_attribute(const std::string& name)

--- a/pybindsrc/hdf5rawdatafile.cpp
+++ b/pybindsrc/hdf5rawdatafile.cpp
@@ -27,10 +27,19 @@ register_hdf5rawdatafile(py::module& m)
   py::class_<HDF5RawDataFile>(m, "_HDF5RawDataFile")
     .def(py::init<std::string>())
 
+    .def("get_attribute_names",
+         &HDF5RawDataFile::get_attribute_names,
+         "Get a list of attribute names")
+
     .def("get_attribute",
          py::overload_cast<const std::string&>
          (&HDF5RawDataFile::get_attribute<std::string>),
          "Get attribute")
+
+    .def("get_int_attribute",
+        py::overload_cast<const std::string&>
+        (&HDF5RawDataFile::get_attribute<size_t>),
+        "Get integer attribute")
 
     .def("get_file_name",
          &HDF5RawDataFile::get_file_name,"Get file name")


### PR DESCRIPTION
This PR resolves #67. The current HDF5 bindings for python does not allow `get_attribute` for any attributes that are not strings since HighFive is not equipped for that type conversion. This is a naive workaround that allows getting attributes as integers. I tried to find attribute type information from HighFive to make the conversion more extension, but found [that users are intended to know the types](https://github.com/BlueBrain/HighFive/issues/451) when using HighFive.

At the same time, I've added a `get_attribute_names` method that lists all available attribute names. Otherwise, finding attributes that can be used was only possible by reading the code on what is written.

This was tested using interactive python and getting the integer attributes `file_index`, `filelayout_version`,  `recorded_size`, and `run_number`.