### PR TITLE
A fix for correct handling of TriggerRecord numbers larger than 2^32

### DIFF
--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -513,11 +513,11 @@ HDF5RawDataFile::get_all_record_ids()
 
     loc = rec_num_string.find(".");
     if (loc == std::string::npos) {
-      m_all_record_ids_in_file.insert(std::make_pair(std::stoi(rec_num_string), 0));
+      m_all_record_ids_in_file.insert(std::make_pair(std::stoll(rec_num_string), 0));
     } else {
       auto seq_num_string = rec_num_string.substr(loc + 1);
       rec_num_string.resize(loc); // remove anything from '.' onwards
-      m_all_record_ids_in_file.insert(std::make_pair(std::stoi(rec_num_string), std::stoi(seq_num_string)));
+      m_all_record_ids_in_file.insert(std::make_pair(std::stoll(rec_num_string), std::stoi(seq_num_string)));
     }
 
   } // end loop over childNames

--- a/unittest/HDF5WriteReadTriggerRecord_test.cxx
+++ b/unittest/HDF5WriteReadTriggerRecord_test.cxx
@@ -402,13 +402,13 @@ BOOST_AUTO_TEST_CASE(ReadFileDatasets)
   // open file for reading now
   h5file_ptr.reset(new HDF5RawDataFile(file_path + "/" + hdf5_filename));
 
-  auto trigger_records = h5file_ptr->get_all_trigger_record_numbers();
-  BOOST_REQUIRE_EQUAL(trigger_count, trigger_records.size());
+  auto trigger_record_ids = h5file_ptr->get_all_trigger_record_ids();
+  BOOST_REQUIRE_EQUAL(trigger_count, trigger_record_ids.size());
 
-  auto first_trigger_record = *(trigger_records.begin());
-  auto last_trigger_record = *(std::next(trigger_records.begin(), trigger_records.size() - 1));
-  BOOST_REQUIRE_EQUAL(1, first_trigger_record);
-  BOOST_REQUIRE_EQUAL(trigger_count, last_trigger_record);
+  auto first_trigger_record_id = *(trigger_record_ids.begin());
+  auto last_trigger_record_id = *(std::next(trigger_record_ids.begin(), trigger_record_ids.size() - 1));
+  BOOST_REQUIRE_EQUAL(1, first_trigger_record_id.first);
+  BOOST_REQUIRE_EQUAL(trigger_count, last_trigger_record_id.first);
 
   auto all_datasets = h5file_ptr->get_dataset_paths();
   BOOST_REQUIRE_EQUAL(trigger_count * (1 + components_per_record), all_datasets.size());
@@ -434,7 +434,7 @@ BOOST_AUTO_TEST_CASE(ReadFileDatasets)
 
   // test access by name
   frag_ptr = h5file_ptr->get_frag_ptr(all_frag_paths.back());
-  BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(), last_trigger_record);
+  BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(), last_trigger_record_id.first);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(), run_number);
 
   // test access by trigger number, type,  element
@@ -497,13 +497,13 @@ BOOST_AUTO_TEST_CASE(ReadFileMaxSequence)
   // open file for reading now
   h5file_ptr.reset(new HDF5RawDataFile(file_path + "/" + hdf5_filename));
 
-  auto trigger_records = h5file_ptr->get_all_trigger_record_numbers();
-  BOOST_REQUIRE_EQUAL(trigger_count, trigger_records.size());
+  auto trigger_record_ids = h5file_ptr->get_all_trigger_record_ids();
+  BOOST_REQUIRE_EQUAL(trigger_count, trigger_record_ids.size());
 
-  auto first_trigger_record = *(trigger_records.begin());
-  auto last_trigger_record = *(std::next(trigger_records.begin(), trigger_records.size() - 1));
-  BOOST_REQUIRE_EQUAL(1, first_trigger_record);
-  BOOST_REQUIRE_EQUAL(trigger_count, last_trigger_record);
+  auto first_trigger_record_id = *(trigger_record_ids.begin());
+  auto last_trigger_record_id = *(std::next(trigger_record_ids.begin(), trigger_record_ids.size() - 1));
+  BOOST_REQUIRE_EQUAL(1, first_trigger_record_id.first);
+  BOOST_REQUIRE_EQUAL(trigger_count, last_trigger_record_id.first);
 
   auto all_datasets = h5file_ptr->get_dataset_paths();
   BOOST_REQUIRE_EQUAL(trigger_count * (1 + components_per_record), all_datasets.size());
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(ReadFileMaxSequence)
 
   // test access by name
   frag_ptr = h5file_ptr->get_frag_ptr(all_frag_paths.back());
-  BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(), last_trigger_record);
+  BOOST_REQUIRE_EQUAL(frag_ptr->get_trigger_number(), last_trigger_record_id.first);
   BOOST_REQUIRE_EQUAL(frag_ptr->get_run_number(), run_number);
 
   // test access by trigger number, type, element
@@ -595,16 +595,13 @@ BOOST_AUTO_TEST_CASE(LargeTriggerRecordNumbers)
   // open file for reading now
   h5file_ptr.reset(new HDF5RawDataFile(file_path + "/" + hdf5_filename));
 
-  auto trigger_records = h5file_ptr->get_all_trigger_record_numbers();
-  BOOST_REQUIRE_EQUAL(trigger_count, trigger_records.size());
-
   auto trigger_record_ids = h5file_ptr->get_all_trigger_record_ids();
   BOOST_REQUIRE_EQUAL(trigger_count, trigger_record_ids.size());
 
-  auto first_trigger_record = *(trigger_records.begin());
-  auto last_trigger_record = *(std::next(trigger_records.begin(), trigger_records.size() - 1));
-  BOOST_REQUIRE_EQUAL(1, first_trigger_record);
-  BOOST_REQUIRE_EQUAL(trigger_number, last_trigger_record);
+  auto first_trigger_record_id = *(trigger_record_ids.begin());
+  auto last_trigger_record_id = *(std::next(trigger_record_ids.begin(), trigger_record_ids.size() - 1));
+  BOOST_REQUIRE_EQUAL(1, first_trigger_record_id.first);
+  BOOST_REQUIRE_EQUAL(trigger_number, last_trigger_record_id.first);
   BOOST_REQUIRE(trigger_number > 0xffffffff);
 
   // clean up the files that were created


### PR DESCRIPTION
While investigating reports of failures in the JSON metadata-creation script at NP04, I noticed that several TimeSlice-based raw data files (e.g. TPStream files) from March of 2023 had large, likely invalid, TimeSlice numbers.  (In this context, large was greater than 2^32 and less than 2^64.)  And, those large TimeSlice numbers had caused the JSON metadata-file-creation script to fail.

I believe that the problem was the use of the `stoi()` system call (string-to-integer) in a couple of places in the `hdf5libs` code, instead of the `stoll()` system all (string-to-long-long).  I have made the appropriate change, and as a way to verify that the change had the desired effect, I added a test case to the HDF5WriteReadTriggerRecord_test.cxx unit test which uses TR numbers larger than 2^32.

An addition set of changes that I made was to switch from the use of the `HDF5RawDataFile::get_all_trigger_record_numbers()` method to the `get_all_trigger_record_ids()` method in the aforementioned unit test, as suggested by runtime messages that remind us that the former method has been deprecated.