### PR TITLE
Fixed HDF5LIBS_TestDumpRecord to handle empty Trigger Candidate fragments

### DIFF
--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -129,12 +129,17 @@ main(int argc, char** argv)
         }
       }
       if (frag_ptr->get_fragment_type() == FragmentType::kTriggerCandidate) {
-        TriggerCandidate* tcptr = static_cast<TriggerCandidate*>(frag_ptr->get_data());
-        ss << "\n\t\t" << "TC type = " << get_trigger_candidate_type_names()[tcptr->data.type]
-           << " (" << static_cast<int>(tcptr->data.type) << "), TC algorithm = "
-           << static_cast<int>(tcptr->data.algorithm) << ", number of TAs = " << tcptr->n_inputs;
-        ss << "\n\t\t" << "Start time = " << tcptr->data.time_start << ", end time = " << tcptr->data.time_end
-           << ", and candidate time = " << tcptr->data.time_candidate;
+        if (frag_ptr->get_size() >= (sizeof(FragmentHeader) + sizeof(TriggerCandidateData))) {
+          TriggerCandidate* tcptr = static_cast<TriggerCandidate*>(frag_ptr->get_data());
+          ss << "\n\t\t" << "TC type = " << get_trigger_candidate_type_names()[tcptr->data.type]
+             << " (" << static_cast<int>(tcptr->data.type) << "), TC algorithm = "
+             << static_cast<int>(tcptr->data.algorithm) << ", number of TAs = " << tcptr->n_inputs;
+          ss << "\n\t\t" << "Start time = " << tcptr->data.time_start << ", end time = " << tcptr->data.time_end
+             << ", and candidate time = " << tcptr->data.time_candidate;
+        }
+        else {
+          ss << "\n\t\t" << "*** Empty Trigger Candidate fragment, no information is available about the TC ***";
+        }
       }
       try {
         auto trh_ptr = h5_raw_data_file.get_trh_ptr(record_id);


### PR DESCRIPTION
Empty TC fragments are rare, but I have seen the under certain conditions, and it is nice to have a clear indication of that emptiness.