### PR TITLE
Added Detailed HSI Fragment Outputs

### DIFF
--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -113,6 +113,10 @@ main(int argc, char** argv)
          << frag_ptr->get_element_id().to_string() << " from subdetector "
          << DetID::subdetector_to_string(static_cast<DetID::Subdetector>(frag_ptr->get_detector_id()))
          << " has size = " << frag_ptr->get_size();
+      if (frag_ptr->get_data_size() == 0) {
+        ss << "\n\t\t" << "*** Empty fragment! Moving to next fragment. ***";
+        continue;
+      }
       if (frag_ptr->get_element_id().subsystem == SourceID::Subsystem::kDetectorReadout) {
         ss << "\n\t\t"
            << "It may contain data from the following detector components:";


### PR DESCRIPTION
These changes added detailed text outputs to `HDF5LIBS_TestDumpRecord.cpp` for the HSI fragments. Here is an example of these outputs on a NP04 run 24177.
```
Hardware_Signal fragment with SourceID HW_Signals_Interface_0x00000000 from subdetector DAQ has size = 100
		Detector ID = 1, Crate = 0, Slot = 0, Link = 0,
		Sequence = 13, Trigger = 1, Version = 1,
		Timestamp = 106718698917776780,
		Input Low Bitmap = 0,
		Input High Bitmap = 0.
		Readout window before = 2144, after = 260000
Hardware_Signal fragment with SourceID HW_Signals_Interface_0x00000001 from subdetector DAQ has size = 100
	Detector ID = 1, Crate = 0, Slot = 0, Link = 1,
	Sequence = 13, Trigger = 16, Version = 1,
	Timestamp = 106718698917776781,
	Input Low Bitmap = 1, Input Low Bit Positions = 0 ,
	Input High Bitmap = 0.
	Readout window before = 2144, after = 260000
```

If input low/high bitmap is zero, then the input low/high bit positions part is omitted since it has no bit positions. This was tested on the run mentioned above.