### PR TITLE
Updated the file layout version number, and added support for it in hdf5_dump.py

### DIFF
--- a/include/hdf5libs/HDF5FileLayout.hpp
+++ b/include/hdf5libs/HDF5FileLayout.hpp
@@ -71,7 +71,7 @@ public:
   /**
    * @brief Constructor from json conf, used in DataWriter. Version always most recent.
    */
-  explicit HDF5FileLayout(hdf5filelayout::FileLayoutParams conf, uint32_t version = 4); // NOLINT(build/unsigned)
+  explicit HDF5FileLayout(hdf5filelayout::FileLayoutParams conf, uint32_t version = 5); // NOLINT(build/unsigned)
 
   uint32_t get_version() const noexcept // NOLINT(build/unsigned)
   {

--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -8,7 +8,8 @@ import os
 import sys
 
 
-FILELAYOUT_VERSION = 4
+FILELAYOUT_MIN_VERSION = 4
+FILELAYOUT_MAX_VERSION = 5
 # detdataformats/include/detdataformats/DetID.hpp
 DETECTOR = {0: 'Unknown', 1: 'DAQ', 2: 'HD_PDS', 3: 'HD_TPC',
             4: 'HD_CRT', 8: 'VD_CathodePDS', 9: 'VD_MembranePDS',
@@ -74,9 +75,11 @@ class DAQDataFile:
         self.record_type = 'TriggerRecord'
         self.clock_speed_hz = 50000000.0
         self.records = []
+        observed_filelayout_version = self.h5file.attrs['filelayout_version']
         if 'filelayout_version' in self.h5file.attrs.keys() and \
-                self.h5file.attrs['filelayout_version'] == FILELAYOUT_VERSION:
-            print(f"INFO: input file matches the supported file layout version: {FILELAYOUT_VERSION}")
+                observed_filelayout_version >= FILELAYOUT_MIN_VERSION and \
+                observed_filelayout_version <= FILELAYOUT_MAX_VERSION:
+            print(f"INFO: input file matches the supported file layout versions: {FILELAYOUT_MIN_VERSION} <= {observed_filelayout_version} <= {FILELAYOUT_MAX_VERSION}")
         else:
             sys.exit(f"ERROR: this script expects a file layout version {FILELAYOUT_VERSION} but this wasn't confirmed in the HDF5 file \"{self.name}\"")
         if 'record_type' in self.h5file.attrs.keys():


### PR DESCRIPTION
These changes are part of the work to provide an additional file-transfer metadata field to offline (`DUNE.daq_test`) and to provide more descriptive values in the existing `data_stream` file-transfer metadata field.

The changes are not directly tied to changes in other repos, but rather are part of bumping up the version number for the FileLayout parameters.  Bumping the version number seems appropriate since the overall work in this area will add two new file-level Attributes in our HDF5 files.  

The change in `hdf5_dump.py` allows it to support both v4 and v5, since the data structures and attributes that it cares about have not changed.

This PR is part of a Deliverable for fddaq-v4.4.0, DUNE-DAQ/daq-deliverables#126, and it is coupled with corresponding PRs in other repos, such as DUNE-DAQ/daqconf#431 and DUNE-DAQ/dfmodules#334.