### PR TITLE
Updated hdf5_dump.py to take into account new larger size for trigger_type

### DIFF
--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -33,11 +33,11 @@ DATA_FORMAT = {
     "TriggerRecord Header": {
         "keys": ['Marker word', 'Version', 'Trigger number',                       # I I Q
                  'Trigger timestamp', 'No. of requested components', 'Run number', # Q Q I
-                 'Error bits', 'Trigger type', 'Sequence number',                  # I H H
+                 'Error bits', 'Trigger type', 'Sequence number',                  # I Q H
                  'Max sequence num', 'Padding',                                    # H H
                  'Source ID version', 'Source ID subsystem', 'Source ID'],         # H H I
-        "size": 56,
-        "unpack string": '<2I3Q2I6HI'
+        "size": 62,
+        "unpack string": '<2I3Q2IQ5HI'
     },
     # daqdataformats/include/daqdataformats/FragmentHeader.hpp
     "Fragment Header":{

--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -34,10 +34,10 @@ DATA_FORMAT = {
         "keys": ['Marker word', 'Version', 'Trigger number',                       # I I Q
                  'Trigger timestamp', 'No. of requested components', 'Run number', # Q Q I
                  'Error bits', 'Trigger type', 'Sequence number',                  # I Q H
-                 'Max sequence num', 'Padding',                                    # H H
+                 'Max sequence num', 'Padding',                                    # H I
                  'Source ID version', 'Source ID subsystem', 'Source ID'],         # H H I
-        "size": 62,
-        "unpack string": '<2I3Q2IQ5HI'
+        "size": 64,
+        "unpack string": '<2I3Q2IQ2HI2HI'
     },
     # daqdataformats/include/daqdataformats/FragmentHeader.hpp
     "Fragment Header":{


### PR DESCRIPTION
This change is a response to the increase in the size of the TriggerRecordHeader::trigger_type field.  Those changes are described [here](https://github.com/DUNE-DAQ/trigger/pull/288).

The change here is straightforward - simply changing the size of that field.

To test the change, run hdf5_dump.py on a raw data file created with the changes mentioned above.

We should look into adding a check that the version of TRH is a supported one, in this script...