### PR TITLE
Added a check on the TRH version in HDF5LIBS_TestDumpRecord

### DIFF
--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -99,6 +99,18 @@ main(int argc, char** argv)
       ss << "\n\tTimeSliceHeader: " << *tsh_ptr;
     } else {
       auto trh_ptr = h5_raw_data_file.get_trh_ptr(record_id);
+      if (trh_ptr->get_header().version != TriggerRecordHeaderData::s_trigger_record_header_version) {
+        std::cout << std::endl;
+        std::cout << "ERROR: The specified data file was written with a version of the DUNE-DAQ software that "
+                  << "used a different version" << std::endl << "       of the TriggerRecordHeader "
+                  << "than this application (built with the current version of the software) is expecting."
+                  << std::endl;
+        std::cout << "Please use a version of the software that is compatible with the data file." << std::endl;
+        std::cout << "(Expected TRH version "
+                  << trh_ptr->get_header().version << " and found version "
+                  << TriggerRecordHeaderData::s_trigger_record_header_version << ".)" << std::endl;
+        std::exit(1);
+      }
       ss << "\n\tTriggerRecordHeader: " << trh_ptr->get_header();
     }
     TLOG() << ss.str();

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -107,8 +107,8 @@ main(int argc, char** argv)
                   << std::endl;
         std::cout << "Please use a version of the software that is compatible with the data file." << std::endl;
         std::cout << "(Expected TRH version "
-                  << trh_ptr->get_header().version << " and found version "
-                  << TriggerRecordHeaderData::s_trigger_record_header_version << ".)" << std::endl;
+                  << TriggerRecordHeaderData::s_trigger_record_header_version << " and found version "
+                  << trh_ptr->get_header().version << ".)" << std::endl;
         std::exit(1);
       }
       ss << "\n\tTriggerRecordHeader: " << trh_ptr->get_header();


### PR DESCRIPTION
This will be helpful in avoiding confusion if users happen to run the new version of the utlitiy on older data files.

To test these changes, run the HDF5LIBS_TestDumpRecord application on raw data files produced with fddaq-v4.3.0 or earlier and confirm that an error message is printed out.