### PR TITLE
Fix HLT/LLT Bit Position Dump

### DIFF
--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -272,9 +272,9 @@ main(int argc, char** argv)
           bit_sniff = 1;
           for (bit_pos = 0; bit_pos < 32; bit_pos++) {
             if (input_low & bit_sniff) {
-              bit_sniff = bit_sniff << 1;
               ss << bit_pos << " ";
             }
+            bit_sniff = bit_sniff << 1;
           }
         }
 
@@ -285,9 +285,9 @@ main(int argc, char** argv)
           bit_sniff = 1;
           for (bit_pos = 0; bit_pos < 32; bit_pos++) {
             if (input_high & bit_sniff) {
-              bit_sniff = bit_sniff << 1;
               ss << bit_pos << " ";
             }
+            bit_sniff = bit_sniff << 1;
           }
         }
         ss << ".";  // Finishes the HSI section.

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -19,6 +19,7 @@
 #include "hdf5libs/hdf5rawdatafile/Nljs.hpp"
 #include "trgdataformats/TriggerObjectOverlay.hpp"
 
+#include <bitset>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -266,26 +267,38 @@ main(int argc, char** argv)
         // Finding the bit positions for input_low and input_high
         uint32_t bit_pos, bit_sniff;
         uint32_t input_low = hsi_ptr->input_low;
+        std::bitset<32> low_bits{input_low};
+        size_t num_bits = low_bits.count();
         ss << ",\n\t\t" << "Input Low Bitmap = " << input_low;
         if (input_low != 0) { // Skip printing the positions if the value is 0.
           ss << ", Input Low Bit Positions = ";
           bit_sniff = 1;
-          for (bit_pos = 0; bit_pos < 32; bit_pos++) {
+          for (bit_pos = 0; bit_pos < 32, num_bits > 0; bit_pos++) {
             if (input_low & bit_sniff) {
-              ss << bit_pos << " ";
+              if (num_bits == 1)
+                ss << bit_pos;
+              else
+                ss << bit_pos << ", ";
+              num_bits--;
             }
             bit_sniff = bit_sniff << 1;
           }
         }
 
         uint32_t input_high = hsi_ptr->input_high;
+        std::bitset<32> high_bits{input_high};
+        num_bits = high_bits.count();
         ss << ",\n\t\t" << "Input High Bitmap = " << input_high;
         if (input_high != 0) {
           ss << ", Input High Bit Positions = ";
           bit_sniff = 1;
-          for (bit_pos = 0; bit_pos < 32; bit_pos++) {
+          for (bit_pos = 0; bit_pos < 32, num_bits > 0; bit_pos++) {
             if (input_high & bit_sniff) {
-              ss << bit_pos << " ";
+              if (num_bits == 1)
+                ss << bit_pos;
+              else
+                ss << bit_pos << ", ";
+              num_bits--;
             }
             bit_sniff = bit_sniff << 1;
           }


### PR DESCRIPTION
There was a bug in the HLT/LLT bit position printing that would only find consecutive bits. This change allows for gaps between bits. For example, a bitmap of `17` would return `0` when the expected output is `0 4`.

Testing this can be done with
```bash
HDF5LIBS_TestDumpRecord /data0/np04hd_raw_run027103_0000_dataflow0_datawriter_0_20240617T081743.hdf5.copied
```
(or any other file that may contain HLT/LLT triggering) and giving attention to the `Hardware_Signal` fragment sections. For example,
```
Hardware_Signal fragment with SourceID HW_Signals_Interface_0x00000000 from subdetector DAQ has size = 744 -----
                Readout window before = 2144, after = 260000
                Detector ID = 1, Crate = 0, Slot = 0, Link = 0,
                Sequence = 712938, Trigger = 36864, Version = 1,
                Timestamp = 107413267854881193,
                Input Low Bitmap = 8388608, Input Low Bit Positions = 23 ,
                Input High Bitmap = 0.
Hardware_Signal fragment with SourceID HW_Signals_Interface_0x00000001 from subdetector DAQ has size = 100 -----
                Readout window before = 2144, after = 260000
                Detector ID = 1, Crate = 0, Slot = 0, Link = 1,
                Sequence = 116, Trigger = 510, Version = 1,
                Timestamp = 107413267854881566,
                Input Low Bitmap = 1, Input Low Bit Positions = 0 ,
                Input High Bitmap = 0.
```