### PR TITLE
Bitmap Loop Correction

### DIFF
--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -273,7 +273,7 @@ main(int argc, char** argv)
         if (input_low != 0) { // Skip printing the positions if the value is 0.
           ss << ", Input Low Bit Positions = ";
           bit_sniff = 1;
-          for (bit_pos = 0; bit_pos < 32, num_bits > 0; bit_pos++) {
+          for (bit_pos = 0; bit_pos < 32 && num_bits > 0; bit_pos++) {
             if (input_low & bit_sniff) {
               if (num_bits == 1)
                 ss << bit_pos;
@@ -292,7 +292,7 @@ main(int argc, char** argv)
         if (input_high != 0) {
           ss << ", Input High Bit Positions = ";
           bit_sniff = 1;
-          for (bit_pos = 0; bit_pos < 32, num_bits > 0; bit_pos++) {
+          for (bit_pos = 0; bit_pos < 32 && num_bits > 0; bit_pos++) {
             if (input_high & bit_sniff) {
               if (num_bits == 1)
                 ss << bit_pos;


### PR DESCRIPTION
Correcting a logic in the bitmap loop. The loop operates as intended (though the `bit_pos < 32` is a **great** guard), but building will bring up a warning.

This PR makes use of the guard and removes the build warning. This can be tested by running `HDF5LIBS_TestDumpRecord` on any HDF5 file and seeing that the before and after is consistent in the `Input Low Bit Positions` and/or `Input High Bit Positions`.

```
Hardware_Signal fragment with SourceID HW_Signals_Interface_0x00000001 from subdetector DAQ has size = 100 -----
                Readout window before = 2144, after = 260000
                Detector ID = 1, Crate = 0, Slot = 0, Link = 1,
                Sequence = 98, Trigger = 510, Version = 1,
                Timestamp = 107413266729881566,
                Input Low Bitmap = 17, Input Low Bit Positions = 0, 4,
                Input High Bitmap = 0.
```