### PR TITLE
Changes to help avoid warning messages when tardy TPs arrive at the TPStreamWriter

### DIFF
--- a/include/hdf5libs/HDF5FileLayout.hpp
+++ b/include/hdf5libs/HDF5FileLayout.hpp
@@ -128,6 +128,11 @@ public:
   std::vector<std::string> get_path_elements(const daqdataformats::FragmentHeader& fh) const;
 
   /**
+   * @brief get the path for the TimeSliceHeader as a single string (e.g. /a/b/c)
+   */
+  std::string get_path_string(const daqdataformats::TimeSliceHeader& tsh) const;
+
+  /**
    * @brief extract Fragment GeoID given path elements
    */
   daqdataformats::SourceID get_source_id_from_path_elements(std::vector<std::string> const& path_elements) const;

--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -101,6 +101,8 @@ ERS_DECLARE_ISSUE(hdf5libs, InvalidHDF5Attribute, "Attribute " << name << " not 
 
 ERS_DECLARE_ISSUE(hdf5libs, HDF5AttributeExists, "Attribute " << name << " already exists.", ((std::string)name))
 
+ERS_DECLARE_ISSUE(hdf5libs, TimeSliceAlreadyExists, "The TimeSlice record for " << name << " already exists.", ((std::string)name))
+
 namespace hdf5libs {
 
 /**

--- a/src/HDF5FileLayout.cpp
+++ b/src/HDF5FileLayout.cpp
@@ -153,6 +153,19 @@ HDF5FileLayout::get_path_elements(const daqdataformats::FragmentHeader& fh) cons
 }
 
 /**
+ * @brief get the path for the TimeSliceHeader as a single string
+ */
+std::string
+HDF5FileLayout::get_path_string(const daqdataformats::TimeSliceHeader& tsh) const
+{
+  std::ostringstream path_string;
+  path_string << "/" << get_timeslice_number_string(tsh.timeslice_number)
+              << "/" << m_conf_params.raw_data_group_name
+              << "/" << tsh.element_id.to_string() << "_" << m_conf_params.record_header_dataset_name;
+  return path_string.str();
+}
+
+/**
  * @brief get the full path for a record header dataset based on trig/seq number
  */
 std::string

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -151,6 +151,9 @@ HDF5RawDataFile::write(const daqdataformats::TriggerRecord& tr)
 void
 HDF5RawDataFile::write(const daqdataformats::TimeSlice& ts)
 {
+  std::string tsh_path = m_file_layout_ptr->get_path_string(ts.get_header());
+  if (m_file_ptr->exist(tsh_path)) {throw TimeSliceAlreadyExists(ERS_HERE, tsh_path);}
+
   // the source_id_path map that we will build up as we write the TR header
   // and fragments (and then write the map into the HDF5 TR_record Group)
   HDF5SourceIDHandler::source_id_path_map_t source_id_path_map;

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -190,6 +190,7 @@ main(int argc, char** argv)
           uint16_t link_id  = (geo_id >> 48) & 0xffff;
           ss << "\n\t\t\t"
              << "subdetector " << DetID::subdetector_to_string(static_cast<DetID::Subdetector>(det_id))
+             << " (" << det_id << ")"
              << ", crate " << crate_id << ", slot " << slot_id << ", link " << link_id;
         }
       }


### PR DESCRIPTION
This PR is related to ones in `daqdataformats` and `dfmodules`, but it can be regression tested and merged by itself.

These changes are part of reducing the number of warning messages when tardy TPs arrive at the TPStreamWriter.  

The changes in this package basically consist of checking whether a TimeSlice has already been written to the HDF5 file, and throwing a custom exception when that happens so that the code that calls `write(TimeSlice)` can react intelligently.

The change in HDF5LIBS_TestDumpRecord is not related to the TPSW changes, but is just a convenience that is being included here for expedience.