### PR TITLE
Copied forward remaining v4 changes.

### DIFF
--- a/include/hdf5libs/HDF5FileLayout.hpp
+++ b/include/hdf5libs/HDF5FileLayout.hpp
@@ -71,7 +71,7 @@ public:
   /**
    * @brief Constructor from json conf, used in DataWriterModule. Version always most recent.
    */
-  explicit HDF5FileLayout(HDF5FileLayoutParameters conf, uint32_t version = 4); // NOLINT(build/unsigned)
+  explicit HDF5FileLayout(HDF5FileLayoutParameters conf, uint32_t version = 5); // NOLINT(build/unsigned)
 
   uint32_t get_version() const noexcept // NOLINT(build/unsigned)
   {
@@ -126,6 +126,11 @@ public:
    * @brief get the correct path for the Fragment
    */
   std::vector<std::string> get_path_elements(const daqdataformats::FragmentHeader& fh) const;
+
+  /**
+   * @brief get the path for the TimeSliceHeader as a single string (e.g. /a/b/c)
+   */
+  std::string get_path_string(const daqdataformats::TimeSliceHeader& tsh) const;
 
   /**
    * @brief extract Fragment GeoID given path elements
@@ -205,31 +210,6 @@ private:
    * @brief map translation for the detector group name to SourceID::Subsystem
    */
   std::map<std::string, daqdataformats::SourceID::Subsystem> m_detector_group_name_to_type_map;
-
-  // quick powers of ten lookup
-  constexpr static uint64_t m_powers_ten[] // NOLINT(build/unsigned)
-    = {
-        1,                    // 1e0
-        10,                   // 1e1
-        100,                  // 1e2
-        1000,                 // 1e3
-        10000,                // 1e4
-        100000,               // 1e5
-        1000000,              // 1e6
-        10000000,             // 1e7
-        100000000,            // 1e8
-        1000000000,           // 1e9
-        10000000000,          // 1e10
-        100000000000,         // 1e11
-        1000000000000,        // 1e12
-        10000000000000,       // 1e13
-        100000000000000,      // 1e14
-        1000000000000000,     // 1e15
-        10000000000000000,    // 1e16
-        100000000000000000,   // 1e17
-        1000000000000000000,  // 1e18
-        10000000000000000000u // 1e19
-      };
 
   /**
    * @brief Fill path parameters maps from FileLayoutParams

--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -99,6 +99,8 @@ ERS_DECLARE_ISSUE(hdf5libs, InvalidHDF5Attribute, "Attribute " << name << " not 
 
 ERS_DECLARE_ISSUE(hdf5libs, HDF5AttributeExists, "Attribute " << name << " already exists.", ((std::string)name))
 
+ERS_DECLARE_ISSUE(hdf5libs, TimeSliceAlreadyExists, "The TimeSlice record for " << name << " already exists.", ((std::string)name))
+
 namespace hdf5libs {
 
 /**

--- a/src/HDF5FileLayout.cpp
+++ b/src/HDF5FileLayout.cpp
@@ -66,24 +66,11 @@ HDF5FileLayout::get_record_number_string(uint64_t record_number, // NOLINT(build
   std::ostringstream record_number_string;
 
   int width = m_conf_params.digits_for_record_number;
-
-  if (record_number >= m_powers_ten[m_conf_params.digits_for_record_number]) {
-    ers::warning(
-      FileLayoutNotEnoughDigitsForPath(ERS_HERE, record_number, m_conf_params.digits_for_record_number));
-    width = 0; // tells it to revert to normal width
-  }
-
-  record_number_string << m_conf_params.record_name_prefix << std::setw(width) << std::setfill('0')
-                       << record_number;
+  record_number_string << m_conf_params.record_name_prefix << std::setw(width) << std::setfill('0') << record_number;
 
   if (m_conf_params.digits_for_sequence_number > 0) {
 
     width = m_conf_params.digits_for_sequence_number;
-    if (seq_num >= m_powers_ten[m_conf_params.digits_for_sequence_number]) {
-      ers::warning(
-        FileLayoutNotEnoughDigitsForPath(ERS_HERE, seq_num, m_conf_params.digits_for_sequence_number));
-      width = 0; // tells it to revert to normal width
-    }
     record_number_string << "." << std::setw(width) << std::setfill('0') << seq_num;
   }
 
@@ -168,6 +155,19 @@ HDF5FileLayout::get_path_elements(const daqdataformats::FragmentHeader& fh) cons
     daqdataformats::fragment_type_to_string(static_cast<daqdataformats::FragmentType>(fh.fragment_type)));
 
   return path_elements;
+}
+
+/**
+ * @brief get the path for the TimeSliceHeader as a single string
+ */
+std::string
+HDF5FileLayout::get_path_string(const daqdataformats::TimeSliceHeader& tsh) const
+{
+  std::ostringstream path_string;
+  path_string << "/" << get_timeslice_number_string(tsh.timeslice_number)
+              << "/" << m_conf_params.raw_data_group_name
+              << "/" << tsh.element_id.to_string() << "_" << m_conf_params.record_header_dataset_name;
+  return path_string.str();
 }
 
 /**

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -151,6 +151,9 @@ HDF5RawDataFile::write(const daqdataformats::TriggerRecord& tr)
 void
 HDF5RawDataFile::write(const daqdataformats::TimeSlice& ts)
 {
+  std::string tsh_path = m_file_layout_ptr->get_path_string(ts.get_header());
+  if (m_file_ptr->exist(tsh_path)) {throw TimeSliceAlreadyExists(ERS_HERE, tsh_path);}
+
   // the source_id_path map that we will build up as we write the TR header
   // and fragments (and then write the map into the HDF5 TR_record Group)
   HDF5SourceIDHandler::source_id_path_map_t source_id_path_map;


### PR DESCRIPTION
This change is part of a wider set that includes one in dfmodules ([PR 383](https://github.com/DUNE-DAQ/dfmodules/pull/383)) and can generally be described as porting HDF5 Attribute changes from v4 to v5.