### PR TITLE
Creation of a utility to help recover raw data files that were not cleanly closed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,5 +33,6 @@ daq_add_python_bindings(*.cpp LINK_LIBRARIES ${PROJECT_NAME} daqdataformats::daq
 daq_add_application(HDF5LIBS_TestReader HDF5LIBS_TestReader.cpp TEST LINK_LIBRARIES ${PROJECT_NAME})
 daq_add_application(HDF5LIBS_TestWriter HDF5LIBS_TestWriter.cpp TEST LINK_LIBRARIES ${PROJECT_NAME})
 daq_add_application(HDF5LIBS_TestDumpRecord HDF5LIBS_TestDumpRecord.cpp TEST LINK_LIBRARIES ${PROJECT_NAME})
+daq_add_application(HDF5LIBS_TestRecoverFile HDF5LIBS_TestRecoverFile.cpp TEST LINK_LIBRARIES ${PROJECT_NAME})
 
 daq_install()

--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -180,8 +180,6 @@ public:
   template<typename T>
   T get_attribute(const std::string& name);
   template<typename T>
-  T get_attribute(const std::string& name, const T& default_value);
-  template<typename T>
   T get_attribute(const HighFive::Group& grp, const std::string& name);
   template<typename T>
   T get_attribute(const HighFive::DataSet& dset, std::string name);
@@ -521,19 +519,6 @@ HDF5RawDataFile::get_attribute(const std::string& name)
 {
   if (!m_file_ptr->hasAttribute(name)) {
     throw InvalidHDF5Attribute(ERS_HERE, name);
-  }
-  auto attr = m_file_ptr->getAttribute(name);
-  T value;
-  attr.read(value);
-  return value;
-}
-
-template<typename T>
-T
-HDF5RawDataFile::get_attribute(const std::string& name, const T& default_value)
-{
-  if (!m_file_ptr->hasAttribute(name)) {
-    return default_value;
   }
   auto attr = m_file_ptr->getAttribute(name);
   T value;

--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -122,6 +122,8 @@ public:
   typedef std::pair<uint64_t, daqdataformats::sequence_number_t> record_id_t; // NOLINT(build/unsigned)
   typedef std::set<record_id_t, std::less<>> record_id_set;
 
+  inline static const std::string s_inprogress_suffix = ".writing";
+
   // constructor for writing
   HDF5RawDataFile(std::string file_name,
                   daqdataformats::run_number_t run_number,
@@ -129,11 +131,11 @@ public:
                   std::string application_name,
                   HDF5FileLayoutParameters fl_params,
                   HDF5SourceIDHandler::source_id_geo_id_map_t srcid_geoid_map,
-                  std::string inprogress_filename_suffix = ".writing",
+                  std::string inprogress_filename_suffix = s_inprogress_suffix,
                   unsigned open_flags = HighFive::File::Create);
 
-  // constructor for reading
-  explicit HDF5RawDataFile(const std::string& file_name);
+  // constructor for reading and optional writing
+  explicit HDF5RawDataFile(const std::string& file_name, bool allow_writing = false);
 
   ~HDF5RawDataFile();
 
@@ -177,6 +179,8 @@ public:
   std::vector<std::string> get_attribute_names();
   template<typename T>
   T get_attribute(const std::string& name);
+  template<typename T>
+  T get_attribute(const std::string& name, const T& default_value);
   template<typename T>
   T get_attribute(const HighFive::Group& grp, const std::string& name);
   template<typename T>
@@ -436,8 +440,8 @@ private:
 
   std::unique_ptr<HighFive::File> m_file_ptr;
   std::unique_ptr<HDF5FileLayout> m_file_layout_ptr;
-  const std::string m_bare_file_name;
-  const unsigned m_open_flags;
+  std::string m_bare_file_name;
+  unsigned m_open_flags;
 
   // Total size of data being written
   size_t m_recorded_size;
@@ -517,6 +521,19 @@ HDF5RawDataFile::get_attribute(const std::string& name)
 {
   if (!m_file_ptr->hasAttribute(name)) {
     throw InvalidHDF5Attribute(ERS_HERE, name);
+  }
+  auto attr = m_file_ptr->getAttribute(name);
+  T value;
+  attr.read(value);
+  return value;
+}
+
+template<typename T>
+T
+HDF5RawDataFile::get_attribute(const std::string& name, const T& default_value)
+{
+  if (!m_file_ptr->hasAttribute(name)) {
+    return default_value;
   }
   auto attr = m_file_ptr->getAttribute(name);
   T value;

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -85,17 +85,23 @@ HDF5RawDataFile::HDF5RawDataFile(std::string file_name,
 HDF5RawDataFile::~HDF5RawDataFile()
 {
   if (m_file_ptr.get() != nullptr && m_open_flags != HighFive::File::ReadOnly) {
-    write_attribute("recorded_size", m_recorded_size);
+    if (! m_file_ptr->hasAttribute("recorded_size")) {
+      write_attribute("recorded_size", m_recorded_size);
+    }
 
-    int64_t timestamp =
-      std::chrono::duration_cast<std::chrono::milliseconds>(system_clock::now().time_since_epoch()).count();
-    std::string file_closing_timestamp = std::to_string(timestamp);
-    write_attribute("closing_timestamp", file_closing_timestamp);
+    if (! m_file_ptr->hasAttribute("closing_timestamp")) {
+      int64_t timestamp =
+	std::chrono::duration_cast<std::chrono::milliseconds>(system_clock::now().time_since_epoch()).count();
+      std::string file_closing_timestamp = std::to_string(timestamp);
+      write_attribute("closing_timestamp", file_closing_timestamp);
+    }
 
     m_file_ptr->flush();
 
-    // rename file to the bare name
-    std::filesystem::rename(m_file_ptr->getName(), m_bare_file_name);
+    // rename file to the bare name, if needed
+    if (m_file_ptr->getName() != m_bare_file_name) {
+      std::filesystem::rename(m_file_ptr->getName(), m_bare_file_name);
+    }
   }
 
   // explicit destruction; not really needed, but nice to be clear...
@@ -301,11 +307,18 @@ HDF5RawDataFile::do_write(std::vector<std::string> const& group_and_dataset_path
 }
 
 /**
- * @brief Constructor for reading a file
+ * @brief Constructor for reading (and optionally writing) a file
  */
-HDF5RawDataFile::HDF5RawDataFile(const std::string& file_name)
+HDF5RawDataFile::HDF5RawDataFile(const std::string& file_name, bool allow_writing)
   : m_open_flags(HighFive::File::ReadOnly)
 {
+  if (allow_writing) {m_open_flags = HighFive::File::ReadWrite;}
+  m_bare_file_name = file_name;
+  size_t pos = m_bare_file_name.rfind(s_inprogress_suffix);
+  if (pos != std::string::npos) {
+    m_bare_file_name.erase(pos);
+  }
+
   // do the file open
   try {
     m_file_ptr = std::make_unique<HighFive::File>(file_name, m_open_flags);

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -74,10 +74,7 @@ main(int argc, char** argv)
   std::ostringstream ss;
 
   ss << "\nFile name: " << h5_raw_data_file.get_file_name();
-  ss << "\n\tRecorded size from class: " << h5_raw_data_file.get_recorded_size();
-
-  auto recorded_size = h5_raw_data_file.get_attribute<size_t>("recorded_size");
-  ss << "\n\tRecorded size from attribute: " << recorded_size;
+  ss << "\n\tRecorded size: " << h5_raw_data_file.get_recorded_size();
 
   auto record_type = h5_raw_data_file.get_record_type();
   ss << "\nRecord type = " << record_type;

--- a/test/apps/HDF5LIBS_TestRecoverFile.cpp
+++ b/test/apps/HDF5LIBS_TestRecoverFile.cpp
@@ -66,24 +66,24 @@ main(int argc, char** argv)
 
   const std::string ifile_name = std::string(argv[1]);
 
-  // open the file for reading and writing
-  HDF5RawDataFile h5_raw_data_file(ifile_name, true);
+  // open the file for reading, initially
+  std::unique_ptr< HDF5RawDataFile> h5file_ptr(new HDF5RawDataFile(ifile_name, false));
 
   size_t last_modified_time = 0;
   struct stat stat_results;
   auto retcode = stat(ifile_name.c_str(), &stat_results);
-  if (retcode == 0) {last_modified_time = stat_results.st_mtime;}
+  if (retcode == 0) {last_modified_time = 1000 * stat_results.st_mtime;} // msec
 
-  std::string closing_timestamp = h5_raw_data_file.get_attribute("closing_timestamp", std::string(""));
+  std::string closing_timestamp = h5file_ptr->get_attribute("closing_timestamp", std::string(""));
 
-  size_t recorded_size = h5_raw_data_file.get_attribute("recorded_size", SIZE_MAX);
+  size_t recorded_size = h5file_ptr->get_attribute("recorded_size", SIZE_MAX);
 
   size_t calculated_recorded_size = 0;
-  auto records = h5_raw_data_file.get_all_record_ids();
+  auto records = h5file_ptr->get_all_record_ids();
   for (auto const& record_id : records) {
-    if (h5_raw_data_file.is_timeslice_type()) {
+    if (h5file_ptr->is_timeslice_type()) {
       try {
-	auto tsh_ptr = h5_raw_data_file.get_tsh_ptr(record_id);
+	auto tsh_ptr = h5file_ptr->get_tsh_ptr(record_id);
 	calculated_recorded_size += sizeof(*tsh_ptr);
       } catch (std::exception const& excpt) {
 	// bad record header, we'll skip the whole TimeSlice
@@ -91,17 +91,17 @@ main(int argc, char** argv)
       }
     } else {
       try {
-	auto trh_ptr = h5_raw_data_file.get_trh_ptr(record_id);
+	auto trh_ptr = h5file_ptr->get_trh_ptr(record_id);
 	calculated_recorded_size += trh_ptr->get_total_size_bytes();
       } catch (std::exception const& excpt) {
 	// bad record header, we'll skip the whole TriggerRecord
 	continue;
       }
     }
-    std::set<SourceID> frag_sid_list = h5_raw_data_file.get_fragment_source_ids(record_id);
+    std::set<SourceID> frag_sid_list = h5file_ptr->get_fragment_source_ids(record_id);
     for (auto const& source_id : frag_sid_list) {
       try {
-	auto frag_ptr = h5_raw_data_file.get_frag_ptr(record_id, source_id);
+	auto frag_ptr = h5file_ptr->get_frag_ptr(record_id, source_id);
 	calculated_recorded_size += frag_ptr->get_size();
       } catch (std::exception const& excpt) {
 	// nothing to do, just leave this fragment out of the sum
@@ -114,26 +114,50 @@ main(int argc, char** argv)
   std::cout << std::endl;
   std::cout << "========================================" << std::endl;
 
-  if (closing_timestamp == "") {
-    std::cout << "The \"closing_timestamp\" Attribute is *not* currently set in the file, and it will be " << std::endl;
-    std::cout << "    set to " << last_modified_time << " if/when the file is recovered." << std::endl;
-  } else {
-    std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp << "." << std::endl;
-  }
+  if (do_recovery) {
 
-  if (recorded_size == SIZE_MAX) {
-    std::cout << "The \"recorded_size\" Attribute is *not* currently set in the file, and it will be " << std::endl;
-    std::cout << "    set to " << calculated_recorded_size << " if/when the file is recovered." << std::endl;
-  } else {
-    std::cout << "The \"recorded_size\" Attribute in the file is currently set to " << recorded_size << "." << std::endl;
-  }
+    // re-open the file for reading and writing
+    h5file_ptr.reset();
+    h5file_ptr.reset(new HDF5RawDataFile(ifile_name, true));
 
-  if (ifile_name.rfind(HDF5RawDataFile::s_inprogress_suffix) != std::string::npos) {
-    std::cout << "The file *does* have the \"" << HDF5RawDataFile::s_inprogress_suffix << "\" suffix, "
-	      << "so it will be renamed if/when it is recovered." << std::endl;
+    std::cout << "Setting the \"recorded_size\" Attribute value to " << calculated_recorded_size << "." << std::endl;
+    h5file_ptr->write_attribute("recorded_size", calculated_recorded_size);
+
+    std::string file_closing_timestamp = std::to_string(last_modified_time);
+    std::cout << "Setting the \"closing_timestamp\" Attribute value to " << file_closing_timestamp << "." << std::endl;
+    h5file_ptr->write_attribute("closing_timestamp", file_closing_timestamp);
+
+    int64_t timestamp =
+      std::chrono::duration_cast<std::chrono::milliseconds>(system_clock::now().time_since_epoch()).count();
+    std::cout << "Setting the \"file_recovery_timestamp\" Attribute value to " << timestamp << "." << std::endl;
+    h5file_ptr->write_attribute("file_recovery_timestamp", timestamp);
+
+    // the HDF5RawDataFile Destructor will handle the file renaming, if that is needed.
+
   } else {
-    std::cout << "The file name does not have the \"" << HDF5RawDataFile::s_inprogress_suffix << "\" suffix, "
-	      << "so it will not be renamed." << std::endl;
+
+    if (closing_timestamp == "") {
+      std::cout << "The \"closing_timestamp\" Attribute is *not* currently set in the file, and it will be " << std::endl;
+      std::cout << "    set to " << last_modified_time << " if/when the file is recovered." << std::endl;
+    } else {
+      std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp << "." << std::endl;
+    }
+
+    if (recorded_size == SIZE_MAX) {
+      std::cout << "The \"recorded_size\" Attribute is *not* currently set in the file, and it will be " << std::endl;
+      std::cout << "    set to " << calculated_recorded_size << " if/when the file is recovered." << std::endl;
+    } else {
+      std::cout << "The \"recorded_size\" Attribute in the file is currently set to " << recorded_size << "." << std::endl;
+    }
+
+    if (ifile_name.rfind(HDF5RawDataFile::s_inprogress_suffix) != std::string::npos) {
+      std::cout << "The file *does* have the \"" << HDF5RawDataFile::s_inprogress_suffix << "\" suffix, "
+		<< "so it will be renamed if/when it is recovered." << std::endl;
+    } else {
+      std::cout << "The file name does not have the \"" << HDF5RawDataFile::s_inprogress_suffix << "\" suffix, "
+		<< "so it will not be renamed." << std::endl;
+    }
+
   }
 
   return 0;

--- a/test/apps/HDF5LIBS_TestRecoverFile.cpp
+++ b/test/apps/HDF5LIBS_TestRecoverFile.cpp
@@ -1,0 +1,140 @@
+/**
+ * @file HDF5RecoverFile.cpp
+ *
+ * Preliminary utility to recover a raw data file that did not get closed properly. 
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2024.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "hdf5libs/HDF5RawDataFile.hpp"
+
+#include "daqdataformats/Fragment.hpp"
+#include "daqdataformats/SourceID.hpp"
+#include "detdataformats/DetID.hpp"
+#include "detdataformats/HSIFrame.hpp"
+#include "logging/Logging.hpp"
+#include "trgdataformats/TriggerObjectOverlay.hpp"
+
+#include <bitset>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+using namespace dunedaq::hdf5libs;
+using namespace dunedaq::daqdataformats;
+using namespace dunedaq::detdataformats;
+using namespace dunedaq::trgdataformats;
+
+void
+print_usage(const char *appname)
+{
+  std::cout << "Usage: " << appname << " [-R] <file_name>" << std::endl;
+  std::cout << "The default behavior is to simply print out the changes that need to be made." << std::endl;
+  std::cout << "The -R option causes the file to be modifed (Recovered)." << std::endl;
+}
+
+int
+main(int argc, char** argv)
+{
+  bool do_recovery = false;
+  signed char opt;
+  while ((opt = getopt(argc, argv, "hR")) != -1) {
+    switch (opt) {
+    case 'h':
+      print_usage(argv[0]);
+      return 1;
+    case 'R':
+      do_recovery = true;
+      break;
+    default: /* '?' */
+      print_usage(argv[0]);
+      return 1;
+    }
+  }
+
+  argc -= (optind-1);
+  argv += (optind-1);
+  if (argc != 2) {
+    print_usage(argv[0]);
+    return 1;
+  }
+
+  const std::string ifile_name = std::string(argv[1]);
+
+  // open the file for reading and writing
+  HDF5RawDataFile h5_raw_data_file(ifile_name, true);
+
+  size_t last_modified_time = 0;
+  struct stat stat_results;
+  auto retcode = stat(ifile_name.c_str(), &stat_results);
+  if (retcode == 0) {last_modified_time = stat_results.st_mtime;}
+
+  std::string closing_timestamp = h5_raw_data_file.get_attribute("closing_timestamp", std::string(""));
+
+  size_t recorded_size = h5_raw_data_file.get_attribute("recorded_size", SIZE_MAX);
+
+  size_t calculated_recorded_size = 0;
+  auto records = h5_raw_data_file.get_all_record_ids();
+  for (auto const& record_id : records) {
+    if (h5_raw_data_file.is_timeslice_type()) {
+      try {
+	auto tsh_ptr = h5_raw_data_file.get_tsh_ptr(record_id);
+	calculated_recorded_size += sizeof(*tsh_ptr);
+      } catch (std::exception const& excpt) {
+	// bad record header, we'll skip the whole TimeSlice
+	continue;
+      }
+    } else {
+      try {
+	auto trh_ptr = h5_raw_data_file.get_trh_ptr(record_id);
+	calculated_recorded_size += trh_ptr->get_total_size_bytes();
+      } catch (std::exception const& excpt) {
+	// bad record header, we'll skip the whole TriggerRecord
+	continue;
+      }
+    }
+    std::set<SourceID> frag_sid_list = h5_raw_data_file.get_fragment_source_ids(record_id);
+    for (auto const& source_id : frag_sid_list) {
+      try {
+	auto frag_ptr = h5_raw_data_file.get_frag_ptr(record_id, source_id);
+	calculated_recorded_size += frag_ptr->get_size();
+      } catch (std::exception const& excpt) {
+	// nothing to do, just leave this fragment out of the sum
+      }
+    }
+  }
+
+
+  std::cout << std::endl;
+  std::cout << std::endl;
+  std::cout << "========================================" << std::endl;
+
+  if (closing_timestamp == "") {
+    std::cout << "The \"closing_timestamp\" Attribute is *not* currently set in the file, and it will be " << std::endl;
+    std::cout << "    set to " << last_modified_time << " if/when the file is recovered." << std::endl;
+  } else {
+    std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp << "." << std::endl;
+  }
+
+  if (recorded_size == SIZE_MAX) {
+    std::cout << "The \"recorded_size\" Attribute is *not* currently set in the file, and it will be " << std::endl;
+    std::cout << "    set to " << calculated_recorded_size << " if/when the file is recovered." << std::endl;
+  } else {
+    std::cout << "The \"recorded_size\" Attribute in the file is currently set to " << recorded_size << "." << std::endl;
+  }
+
+  if (ifile_name.rfind(HDF5RawDataFile::s_inprogress_suffix) != std::string::npos) {
+    std::cout << "The file *does* have the \"" << HDF5RawDataFile::s_inprogress_suffix << "\" suffix, "
+	      << "so it will be renamed if/when it is recovered." << std::endl;
+  } else {
+    std::cout << "The file name does not have the \"" << HDF5RawDataFile::s_inprogress_suffix << "\" suffix, "
+	      << "so it will not be renamed." << std::endl;
+  }
+
+  return 0;
+} // NOLINT

--- a/test/apps/HDF5LIBS_TestRecoverFile.cpp
+++ b/test/apps/HDF5LIBS_TestRecoverFile.cpp
@@ -106,9 +106,15 @@ main(int argc, char** argv)
   bool ct_attr_exists = (std::count(attr_names.begin(), attr_names.end(), "closing_timestamp") >= 1);
   bool rs_attr_exists = (std::count(attr_names.begin(), attr_names.end(), "recorded_size") >= 1);
 
-  std::string closing_timestamp = "";
+  size_t closing_timestamp = 0;
   if (ct_attr_exists) {
-    closing_timestamp = h5file_ptr->get_attribute<std::string>("closing_timestamp");
+    if (h5file_ptr->get_file_layout().get_version() >= 6) {
+      closing_timestamp = h5file_ptr->get_attribute<size_t>("closing_timestamp");
+    } else {
+      auto clts_string = h5file_ptr->get_attribute<std::string>("closing_timestamp");
+      char* nds = 0;
+      closing_timestamp = strtol(clts_string.c_str(), &nds, 10);
+    }
   }
   size_t recorded_size = SIZE_MAX;
   if (rs_attr_exists) {
@@ -126,10 +132,15 @@ main(int argc, char** argv)
     h5file_ptr.reset(new HDF5RawDataFile(ifile_name, true));
 
     if (!ct_attr_exists) {
-      std::string file_closing_timestamp = std::to_string(last_modified_time);
-      std::cout << "Setting the \"closing_timestamp\" Attribute value to " << file_closing_timestamp << "."
-                << std::endl;
-      h5file_ptr->write_attribute("closing_timestamp", file_closing_timestamp);
+      if (h5file_ptr->get_file_layout().get_version() >= 6) {
+        std::cout << "Setting the \"closing_timestamp\" Attribute value to " << last_modified_time << "." << std::endl;
+        h5file_ptr->write_attribute("closing_timestamp", last_modified_time);
+      } else {
+        std::string file_closing_timestamp = std::to_string(last_modified_time);
+        std::cout << "Setting the \"closing_timestamp\" Attribute value to " << file_closing_timestamp << "."
+                  << std::endl;
+        h5file_ptr->write_attribute("closing_timestamp", file_closing_timestamp);
+      }
     } else {
       std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp
                 << ", and it will not be over-written." << std::endl;
@@ -161,10 +172,16 @@ main(int argc, char** argv)
     if (std::count(attr_names.begin(), attr_names.end(), "creation_timestamp") == 0) {
       std::cout << "The \"creation_timestamp\" Attribute is *not* currently set in the file." << std::endl;
     } else {
-      std::string creation_timestamp = h5file_ptr->get_attribute<std::string>("creation_timestamp");
-      char* nds = 0;
-      time_t blah = strtol(creation_timestamp.c_str(), &nds, 10) / 1000;
-      tm* gmtm = gmtime(&blah);
+      size_t creation_timestamp = 0;
+      if (h5file_ptr->get_file_layout().get_version() >= 6) {
+        creation_timestamp = h5file_ptr->get_attribute<size_t>("creation_timestamp");
+      } else {
+        auto crts_string = h5file_ptr->get_attribute<std::string>("creation_timestamp");
+        char* nds = 0;
+        creation_timestamp = strtol(crts_string.c_str(), &nds, 10);
+      }
+      time_t tmp_time = creation_timestamp / 1000;
+      tm* gmtm = gmtime(&tmp_time);
       std::cout << "The \"creation_timestamp\" Attribute in the file is currently set to " << creation_timestamp << ","
                 << std::endl
                 << "    which corresponds to (UTC) " << asctime(gmtm);
@@ -175,12 +192,11 @@ main(int argc, char** argv)
                 << std::endl
                 << "    set to " << last_modified_time << " if/when the file is recovered." << std::endl;
     } else {
-      char* nds = 0;
-      time_t blah = strtol(closing_timestamp.c_str(), &nds, 10) / 1000;
-      tm* gmtm = gmtime(&blah);
+      time_t tmp_time = closing_timestamp / 1000;
+      tm* gmtm = gmtime(&tmp_time);
       std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp << ","
                 << std::endl
-                << "    which corresponds to (UTC) " << asctime(gmtm)  // no std::endl needed with asctime()
+                << "    which corresponds to (UTC) " << asctime(gmtm) // no std::endl needed with asctime()
                 << "    (The recalculated closing time is " << last_modified_time << ".)" << std::endl;
     }
 
@@ -197,8 +213,8 @@ main(int argc, char** argv)
       std::cout << "The \"file_recovery_timestamp\" Attribute is *not* currently set in the file." << std::endl;
     } else {
       size_t fr_timestamp = h5file_ptr->get_attribute<size_t>("file_recovery_timestamp");
-      time_t blah = fr_timestamp / 1000;
-      tm* gmtm = gmtime(&blah);
+      time_t tmp_time = fr_timestamp / 1000;
+      tm* gmtm = gmtime(&tmp_time);
       std::cout << "The \"file_recovery_timestamp\" Attribute in the file is currently set to " << fr_timestamp << ","
                 << std::endl
                 << "    which corresponds to (UTC) " << asctime(gmtm);

--- a/test/apps/HDF5LIBS_TestRecoverFile.cpp
+++ b/test/apps/HDF5LIBS_TestRecoverFile.cpp
@@ -1,7 +1,7 @@
 /**
  * @file HDF5RecoverFile.cpp
  *
- * Preliminary utility to recover a raw data file that did not get closed properly. 
+ * Preliminary utility to recover a raw data file that did not get closed properly.
  *
  * This is part of the DUNE DAQ Software Suite, copyright 2024.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -12,26 +12,17 @@
 
 #include "daqdataformats/Fragment.hpp"
 #include "daqdataformats/SourceID.hpp"
-#include "detdataformats/DetID.hpp"
-#include "detdataformats/HSIFrame.hpp"
-#include "logging/Logging.hpp"
-#include "trgdataformats/TriggerObjectOverlay.hpp"
 
-#include <bitset>
-#include <fstream>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 using namespace dunedaq::hdf5libs;
 using namespace dunedaq::daqdataformats;
-using namespace dunedaq::detdataformats;
-using namespace dunedaq::trgdataformats;
 
 void
-print_usage(const char *appname)
+print_usage(const char* appname)
 {
   std::cout << "Usage: " << appname << " [-R] <file_name>" << std::endl;
   std::cout << "The default behavior is to simply print out the changes that need to be made." << std::endl;
@@ -45,20 +36,20 @@ main(int argc, char** argv)
   signed char opt;
   while ((opt = getopt(argc, argv, "hR")) != -1) {
     switch (opt) {
-    case 'h':
-      print_usage(argv[0]);
-      return 1;
-    case 'R':
-      do_recovery = true;
-      break;
-    default: /* '?' */
-      print_usage(argv[0]);
-      return 1;
+      case 'h':
+        print_usage(argv[0]);
+        return 1;
+      case 'R':
+        do_recovery = true;
+        break;
+      default: /* '?' */
+        print_usage(argv[0]);
+        return 1;
     }
   }
 
-  argc -= (optind-1);
-  argv += (optind-1);
+  argc -= (optind - 1);
+  argv += (optind - 1);
   if (argc != 2) {
     print_usage(argv[0]);
     return 1;
@@ -67,48 +58,62 @@ main(int argc, char** argv)
   const std::string ifile_name = std::string(argv[1]);
 
   // open the file for reading, initially
-  std::unique_ptr< HDF5RawDataFile> h5file_ptr(new HDF5RawDataFile(ifile_name, false));
+  std::unique_ptr<HDF5RawDataFile> h5file_ptr(new HDF5RawDataFile(ifile_name, false));
 
+  // determine a reasonable value for the file-closing time based on the Linux
+  // file system last-modified time
   size_t last_modified_time = 0;
   struct stat stat_results;
   auto retcode = stat(ifile_name.c_str(), &stat_results);
-  if (retcode == 0) {last_modified_time = 1000 * stat_results.st_mtime;} // msec
+  if (retcode == 0) {
+    last_modified_time = 1000 * stat_results.st_mtime;
+  } // msec
 
-  std::string closing_timestamp = h5file_ptr->get_attribute("closing_timestamp", std::string(""));
-
-  size_t recorded_size = h5file_ptr->get_attribute("recorded_size", SIZE_MAX);
-
+  // determine a reasonable value for the size of the recorded data in the file by
+  // looping through all of the records and fragments
   size_t calculated_recorded_size = 0;
   auto records = h5file_ptr->get_all_record_ids();
   for (auto const& record_id : records) {
     if (h5file_ptr->is_timeslice_type()) {
       try {
-	auto tsh_ptr = h5file_ptr->get_tsh_ptr(record_id);
-	calculated_recorded_size += sizeof(*tsh_ptr);
+        auto tsh_ptr = h5file_ptr->get_tsh_ptr(record_id);
+        calculated_recorded_size += sizeof(*tsh_ptr);
       } catch (std::exception const& excpt) {
-	// bad record header, we'll skip the whole TimeSlice
-	continue;
+        // bad record header, we'll skip the whole TimeSlice
+        continue;
       }
     } else {
       try {
-	auto trh_ptr = h5file_ptr->get_trh_ptr(record_id);
-	calculated_recorded_size += trh_ptr->get_total_size_bytes();
+        auto trh_ptr = h5file_ptr->get_trh_ptr(record_id);
+        calculated_recorded_size += trh_ptr->get_total_size_bytes();
       } catch (std::exception const& excpt) {
-	// bad record header, we'll skip the whole TriggerRecord
-	continue;
+        // bad record header, we'll skip the whole TriggerRecord
+        continue;
       }
     }
     std::set<SourceID> frag_sid_list = h5file_ptr->get_fragment_source_ids(record_id);
     for (auto const& source_id : frag_sid_list) {
       try {
-	auto frag_ptr = h5file_ptr->get_frag_ptr(record_id, source_id);
-	calculated_recorded_size += frag_ptr->get_size();
+        auto frag_ptr = h5file_ptr->get_frag_ptr(record_id, source_id);
+        calculated_recorded_size += frag_ptr->get_size();
       } catch (std::exception const& excpt) {
-	// nothing to do, just leave this fragment out of the sum
+        // nothing to do, just leave this fragment out of the sum
       }
     }
   }
 
+  std::vector<std::string> attr_names = h5file_ptr->get_attribute_names();
+  bool ct_attr_exists = (std::count(attr_names.begin(), attr_names.end(), "closing_timestamp") >= 1);
+  bool rs_attr_exists = (std::count(attr_names.begin(), attr_names.end(), "recorded_size") >= 1);
+
+  std::string closing_timestamp = "";
+  if (ct_attr_exists) {
+    closing_timestamp = h5file_ptr->get_attribute<std::string>("closing_timestamp");
+  }
+  size_t recorded_size = SIZE_MAX;
+  if (rs_attr_exists) {
+    recorded_size = h5file_ptr->get_attribute<size_t>("recorded_size");
+  }
 
   std::cout << std::endl;
   std::cout << std::endl;
@@ -120,44 +125,86 @@ main(int argc, char** argv)
     h5file_ptr.reset();
     h5file_ptr.reset(new HDF5RawDataFile(ifile_name, true));
 
-    std::cout << "Setting the \"recorded_size\" Attribute value to " << calculated_recorded_size << "." << std::endl;
-    h5file_ptr->write_attribute("recorded_size", calculated_recorded_size);
+    if (!ct_attr_exists) {
+      std::string file_closing_timestamp = std::to_string(last_modified_time);
+      std::cout << "Setting the \"closing_timestamp\" Attribute value to " << file_closing_timestamp << "."
+                << std::endl;
+      h5file_ptr->write_attribute("closing_timestamp", file_closing_timestamp);
+    } else {
+      std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp
+                << ", and it will not be over-written." << std::endl;
+    }
 
-    std::string file_closing_timestamp = std::to_string(last_modified_time);
-    std::cout << "Setting the \"closing_timestamp\" Attribute value to " << file_closing_timestamp << "." << std::endl;
-    h5file_ptr->write_attribute("closing_timestamp", file_closing_timestamp);
+    if (!rs_attr_exists) {
+      std::cout << "Setting the \"recorded_size\" Attribute value to " << calculated_recorded_size << "." << std::endl;
+      h5file_ptr->write_attribute("recorded_size", calculated_recorded_size);
+    } else {
+      std::cout << "The \"recorded_size\" Attribute in the file is currently set to " << recorded_size
+                << ", and it will not be over-written." << std::endl;
+    }
 
-    int64_t timestamp =
-      std::chrono::duration_cast<std::chrono::milliseconds>(system_clock::now().time_since_epoch()).count();
-    std::cout << "Setting the \"file_recovery_timestamp\" Attribute value to " << timestamp << "." << std::endl;
-    h5file_ptr->write_attribute("file_recovery_timestamp", timestamp);
+    if (std::count(attr_names.begin(), attr_names.end(), "file_recovery_timestamp") == 0) {
+      int64_t timestamp =
+        std::chrono::duration_cast<std::chrono::milliseconds>(system_clock::now().time_since_epoch()).count();
+      std::cout << "Setting the \"file_recovery_timestamp\" Attribute value to " << timestamp << "." << std::endl;
+      h5file_ptr->write_attribute("file_recovery_timestamp", timestamp);
+    } else {
+      size_t fr_timestamp = h5file_ptr->get_attribute<size_t>("file_recovery_timestamp");
+      std::cout << "The \"file_recovery_timestamp\" Attribute in the file is currently set to " << fr_timestamp
+                << ", and it will not be over-written." << std::endl;
+    }
 
     // the HDF5RawDataFile Destructor will handle the file renaming, if that is needed.
 
   } else {
 
-    if (closing_timestamp == "") {
-      std::cout << "The \"closing_timestamp\" Attribute is *not* currently set in the file, and it will be " << std::endl;
-      std::cout << "    set to " << last_modified_time << " if/when the file is recovered." << std::endl;
+    if (std::count(attr_names.begin(), attr_names.end(), "creation_timestamp") == 0) {
+      std::cout << "The \"creation_timestamp\" Attribute is *not* currently set in the file." << std::endl;
     } else {
-      std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp << "." << std::endl;
+      std::string creation_timestamp = h5file_ptr->get_attribute<std::string>("creation_timestamp");
+      char* nds = 0;
+      time_t blah = strtol(creation_timestamp.c_str(), &nds, 10) / 1000;
+      tm* gmtm = gmtime(&blah);
+      std::cout << "The \"creation_timestamp\" Attribute in the file is currently set to " << creation_timestamp
+		<< "," << std::endl << "    which corresponds to (UTC) " << asctime(gmtm);
     }
 
-    if (recorded_size == SIZE_MAX) {
-      std::cout << "The \"recorded_size\" Attribute is *not* currently set in the file, and it will be " << std::endl;
-      std::cout << "    set to " << calculated_recorded_size << " if/when the file is recovered." << std::endl;
+    if (!ct_attr_exists) {
+      std::cout << "The \"closing_timestamp\" Attribute is *not* currently set in the file, and it will be "
+                << std::endl << "    set to " << last_modified_time << " if/when the file is recovered." << std::endl;
     } else {
-      std::cout << "The \"recorded_size\" Attribute in the file is currently set to " << recorded_size << "." << std::endl;
+      char* nds = 0;
+      time_t blah = strtol(closing_timestamp.c_str(), &nds, 10) / 1000;
+      tm* gmtm = gmtime(&blah);
+      std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp
+                << "," << std::endl << "    which corresponds to (UTC) " << asctime(gmtm);
+    }
+
+    if (!rs_attr_exists) {
+      std::cout << "The \"recorded_size\" Attribute is *not* currently set in the file, and it will be " << std::endl
+		<< "    set to " << calculated_recorded_size << " if/when the file is recovered." << std::endl;
+    } else {
+      std::cout << "The \"recorded_size\" Attribute in the file is currently set to " << recorded_size << "."
+                << std::endl;
+    }
+
+    if (std::count(attr_names.begin(), attr_names.end(), "file_recovery_timestamp") == 0) {
+      std::cout << "The \"file_recovery_timestamp\" Attribute is *not* currently set in the file." << std::endl;
+    } else {
+      size_t fr_timestamp = h5file_ptr->get_attribute<size_t>("file_recovery_timestamp");
+      time_t blah = fr_timestamp / 1000;
+      tm* gmtm = gmtime(&blah);
+      std::cout << "The \"file_recovery_timestamp\" Attribute in the file is currently set to " << fr_timestamp
+                << "," << std::endl << "    which corresponds to (UTC) " << asctime(gmtm);
     }
 
     if (ifile_name.rfind(HDF5RawDataFile::s_inprogress_suffix) != std::string::npos) {
       std::cout << "The file *does* have the \"" << HDF5RawDataFile::s_inprogress_suffix << "\" suffix, "
-		<< "so it will be renamed if/when it is recovered." << std::endl;
+                << "so it will be renamed if/when it is recovered." << std::endl;
     } else {
       std::cout << "The file name does not have the \"" << HDF5RawDataFile::s_inprogress_suffix << "\" suffix, "
-		<< "so it will not be renamed." << std::endl;
+                << "so it will not be renamed." << std::endl;
     }
-
   }
 
   return 0;

--- a/test/apps/HDF5LIBS_TestRecoverFile.cpp
+++ b/test/apps/HDF5LIBS_TestRecoverFile.cpp
@@ -165,27 +165,32 @@ main(int argc, char** argv)
       char* nds = 0;
       time_t blah = strtol(creation_timestamp.c_str(), &nds, 10) / 1000;
       tm* gmtm = gmtime(&blah);
-      std::cout << "The \"creation_timestamp\" Attribute in the file is currently set to " << creation_timestamp
-		<< "," << std::endl << "    which corresponds to (UTC) " << asctime(gmtm);
+      std::cout << "The \"creation_timestamp\" Attribute in the file is currently set to " << creation_timestamp << ","
+                << std::endl
+                << "    which corresponds to (UTC) " << asctime(gmtm);
     }
 
     if (!ct_attr_exists) {
       std::cout << "The \"closing_timestamp\" Attribute is *not* currently set in the file, and it will be "
-                << std::endl << "    set to " << last_modified_time << " if/when the file is recovered." << std::endl;
+                << std::endl
+                << "    set to " << last_modified_time << " if/when the file is recovered." << std::endl;
     } else {
       char* nds = 0;
       time_t blah = strtol(closing_timestamp.c_str(), &nds, 10) / 1000;
       tm* gmtm = gmtime(&blah);
-      std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp
-                << "," << std::endl << "    which corresponds to (UTC) " << asctime(gmtm);
+      std::cout << "The \"closing_timestamp\" Attribute in the file is currently set to " << closing_timestamp << ","
+                << std::endl
+                << "    which corresponds to (UTC) " << asctime(gmtm)  // no std::endl needed with asctime()
+                << "    (The recalculated closing time is " << last_modified_time << ".)" << std::endl;
     }
 
     if (!rs_attr_exists) {
       std::cout << "The \"recorded_size\" Attribute is *not* currently set in the file, and it will be " << std::endl
-		<< "    set to " << calculated_recorded_size << " if/when the file is recovered." << std::endl;
+                << "    set to " << calculated_recorded_size << " if/when the file is recovered." << std::endl;
     } else {
       std::cout << "The \"recorded_size\" Attribute in the file is currently set to " << recorded_size << "."
-                << std::endl;
+                << std::endl
+                << "    (The recalculated recorded size is " << calculated_recorded_size << ".)" << std::endl;
     }
 
     if (std::count(attr_names.begin(), attr_names.end(), "file_recovery_timestamp") == 0) {
@@ -194,8 +199,9 @@ main(int argc, char** argv)
       size_t fr_timestamp = h5file_ptr->get_attribute<size_t>("file_recovery_timestamp");
       time_t blah = fr_timestamp / 1000;
       tm* gmtm = gmtime(&blah);
-      std::cout << "The \"file_recovery_timestamp\" Attribute in the file is currently set to " << fr_timestamp
-                << "," << std::endl << "    which corresponds to (UTC) " << asctime(gmtm);
+      std::cout << "The \"file_recovery_timestamp\" Attribute in the file is currently set to " << fr_timestamp << ","
+                << std::endl
+                << "    which corresponds to (UTC) " << asctime(gmtm);
     }
 
     if (ifile_name.rfind(HDF5RawDataFile::s_inprogress_suffix) != std::string::npos) {


### PR DESCRIPTION
Usage: ` HDF5LIBS_TestRecoverFile [-R] <filename>`

This app has two modes.  

The first mode (without the "-R" command-line option), prints out information about the relevant HDF5 file-level Attributes in the file.  It also prints out the values that will be used if/when the file is recovered.

The second mode (with the "-R" command-line option), sets necessary HDF5 Attributes in the file to appropriate values.

Re-running this app on a recovered file *is* possible, and this can be useful in verifying that the changes that were made were reasonable.

There are a couple of broken files in `np04-srv-005:/data2/kurtMetadataTests/reference/` that can be used for testing this new app.  If you use "cp -p <source> <target>", that will preserve the original timestamp of these sample data file(s).