### PR TITLE
Moved the get_attribute_names method from the HDF5RawDataFile header …

### DIFF
--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -506,11 +506,6 @@ HDF5RawDataFile::write_attribute(HighFive::DataSet& dset, const std::string& nam
     ers::warning(HDF5AttributeExists(ERS_HERE, name));
 }
 
-std::vector<std::string> HDF5RawDataFile::get_attribute_names()
-{
-  return m_file_ptr->listAttributeNames();
-}
-
 template<typename T>
 T
 HDF5RawDataFile::get_attribute(const std::string& name)

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -104,6 +104,15 @@ HDF5RawDataFile::~HDF5RawDataFile()
 }
 
 /**
+ * @brief Fetch the list of all file-level Attribute names.
+ */
+std::vector<std::string>
+HDF5RawDataFile::HDF5RawDataFile::get_attribute_names()
+{
+  return m_file_ptr->listAttributeNames();
+}
+
+/**
  * @brief Write a TriggerRecord to the file.
  */
 void


### PR DESCRIPTION
…file to the source file.

This was requested in Issue #105 .