### PR TITLE
Store file creation and closing timestamps as integers in HDF5 file Attributes

### DIFF
--- a/include/hdf5libs/HDF5FileLayout.hpp
+++ b/include/hdf5libs/HDF5FileLayout.hpp
@@ -71,7 +71,7 @@ public:
   /**
    * @brief Constructor from json conf, used in DataWriterModule. Version always most recent.
    */
-  explicit HDF5FileLayout(HDF5FileLayoutParameters conf, uint32_t version = 5); // NOLINT(build/unsigned)
+  explicit HDF5FileLayout(HDF5FileLayoutParameters conf, uint32_t version = 6); // NOLINT(build/unsigned)
 
   uint32_t get_version() const noexcept // NOLINT(build/unsigned)
   {

--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -9,7 +9,7 @@ import sys
 
 # Current allowed range of file layout versions
 FILELAYOUT_MIN_VERSION = 4
-FILELAYOUT_MAX_VERSION = 5
+FILELAYOUT_MAX_VERSION = 6
 
 # Current header versions
 TRIGGER_RECORD_HEADER_VERSION = 4

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -55,9 +55,8 @@ HDF5RawDataFile::HDF5RawDataFile(std::string file_name,
 
   m_recorded_size = 0;
 
-  int64_t timestamp =
+  size_t file_creation_timestamp =
     std::chrono::duration_cast<std::chrono::milliseconds>(system_clock::now().time_since_epoch()).count();
-  std::string file_creation_timestamp = std::to_string(timestamp);
 
   TLOG_DEBUG(TLVL_BASIC) << "Created HDF5 file (" << file_name << ") at time " << file_creation_timestamp << " .";
 
@@ -87,9 +86,8 @@ HDF5RawDataFile::~HDF5RawDataFile()
   if (m_file_ptr.get() != nullptr && m_open_flags != HighFive::File::ReadOnly) {
     write_attribute("recorded_size", m_recorded_size);
 
-    int64_t timestamp =
+    size_t file_closing_timestamp =
       std::chrono::duration_cast<std::chrono::milliseconds>(system_clock::now().time_since_epoch()).count();
-    std::string file_closing_timestamp = std::to_string(timestamp);
     write_attribute("closing_timestamp", file_closing_timestamp);
 
     m_file_ptr->flush();

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -88,12 +88,17 @@ main(int argc, char** argv)
   // get some file attributes
   auto run_number = h5_raw_data_file.get_attribute<unsigned int>("run_number");
   auto file_index = h5_raw_data_file.get_attribute<unsigned int>("file_index");
-  auto creation_timestamp = h5_raw_data_file.get_attribute<std::string>("creation_timestamp");
   auto app_name = h5_raw_data_file.get_attribute<std::string>("application_name");
 
   ss << "\n\tRun number: " << run_number;
   ss << "\n\tFile index: " << file_index;
-  ss << "\n\tCreation timestamp: " << creation_timestamp;
+  if (h5_raw_data_file.get_file_layout().get_version() >= 6) {
+    auto creation_timestamp = h5_raw_data_file.get_attribute<size_t>("creation_timestamp");
+    ss << "\n\tCreation timestamp: " << creation_timestamp;
+  } else {
+    auto creation_timestamp = h5_raw_data_file.get_attribute<std::string>("creation_timestamp");
+    ss << "\n\tCreation timestamp: " << creation_timestamp;
+  }
   ss << "\n\tWriter app name: " << app_name;
 
   TLOG() << ss.str();

--- a/test/apps/HDF5LIBS_TestReader.cpp
+++ b/test/apps/HDF5LIBS_TestReader.cpp
@@ -64,12 +64,17 @@ main(int argc, char** argv)
   // get some file attributes
   auto run_number = h5_raw_data_file.get_attribute<unsigned int>("run_number");
   auto file_index = h5_raw_data_file.get_attribute<unsigned int>("file_index");
-  auto creation_timestamp = h5_raw_data_file.get_attribute<std::string>("creation_timestamp");
   auto app_name = h5_raw_data_file.get_attribute<std::string>("application_name");
 
   ss << "\n\tRun number: " << run_number;
   ss << "\n\tFile index: " << file_index;
-  ss << "\n\tCreation timestamp: " << creation_timestamp;
+  if (h5_raw_data_file.get_file_layout().get_version() >= 6) {
+    auto creation_timestamp = h5_raw_data_file.get_attribute<size_t>("creation_timestamp");
+    ss << "\n\tCreation timestamp: " << creation_timestamp;
+  } else {
+    auto creation_timestamp = h5_raw_data_file.get_attribute<std::string>("creation_timestamp");
+    ss << "\n\tCreation timestamp: " << creation_timestamp;
+  }
   ss << "\n\tWriter app name: " << app_name;
 
   TLOG() << ss.str();


### PR DESCRIPTION
At the moment, the `creation_timestamp` and `closing_timestamp` file-level Attributes that appear in our HDF5 data files have data types of "string".  I believe that this is a historical artifact left over from a time when those Attributes contained values that were formatted as date strings instead of the number of seconds since the Epoch.

It seems reasonable to fix this oddity (having integer values represented as strings) so that all of the numeric values that are stored in HDF5 Attributes have numeric data types.  The changes in this Pull Request, along with [associated changes](https://github.com/DUNE-DAQ/rawdatautils/pull/85) in the `rawdatautils` package, make this change.  

To help make this change clear to users of the DAQ HDF5 data files, the version of the file_layout_version was bumped from 5 to 6 as part of these changes.  And, the usual tools that we use to look at HDF5 data files were updated to take the new file_layout_version into account.

I don't believe that this will directly affect offline users since they focus on the file-transfer metadata that we provide with each raw data file (they don't look at the HDF5 file Attributes directly).  And, we have updated our script that generates the file-transfer metadata as part of these changes (that is in `rawdatautils/scripts/print_values_for_file_transfer_metadata.py`).

Here are suggested steps for testing these changes along with the ones in `rawdatautils`:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest_v5
dbt-create -n NFD_DEV_241209_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/hdf5libs.git -b kbiery/integer_file_creation_and_closing_timestamps
git clone https://github.com/DUNE-DAQ/rawdatautils.git -b kbiery/integer_file_creation_and_closing_timestamps
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

mkdir rundir
cd rundir

drunc-unified-shell ssh-standalone config/daqsystemtest/example-configs.data.xml local-1x1-config boot --no-override-logs wait 5 conf wait 3 start --run-number 101 enable-triggers wait 10 disable-triggers drain-dataflow stop-trigger-sources stop scrap terminate

echo ""
echo "================================================================================"
echo ""
print_values_for_file_transfer_metadata.py test_raw_run000101_0000_df-01_dw_0_*.hdf5

echo ""
echo "================================================================================"
echo ""
h5dump -A test_raw_run000101_0000_df-01_dw_0_*.hdf5 | egrep -A 7 'closing_timestamp|creation_timestamp'

echo ""
echo "================================================================================"
echo ""
hdf5_dump.py -n 1 -p both -f test_raw_run000101_0000_df-01_dw_0_*.hdf5

echo ""
echo "================================================================================"
echo ""
hdf5_dump.py -c -f test_raw_run000101_0000_df-01_dw_0_*.hdf5

echo ""
echo "================================================================================"
echo ""
HDF5LIBS_TestDumpRecord -n 1 test_raw_run000101_0000_df-01_dw_0_*.hdf5
```