### PR TITLE
Added fragment-lookup function for cases in which the subdetector type will matter

### DIFF
--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -333,6 +333,11 @@ public:
     return get_source_ids_for_fragment_type(std::make_pair(rec_num, seq_num), frag_type_name);
   }
 
+  // get SourceIDs for given fragment type and subdetector in a record
+  std::set<daqdataformats::SourceID> get_source_ids_for_fragtype_and_detid(const record_id_t& rid,
+                                                                           const std::string& frag_type_name,
+                                                                           const std::string& subdet_name);
+
   // get SourceIDs for given subdetector in a record
   std::set<daqdataformats::SourceID> get_source_ids_for_subdetector(const record_id_t& rid,
                                                                     const detdataformats::DetID::Subdetector subdet);

--- a/include/hdf5libs/HDF5RawDataFile.hpp
+++ b/include/hdf5libs/HDF5RawDataFile.hpp
@@ -101,6 +101,12 @@ ERS_DECLARE_ISSUE(hdf5libs, HDF5AttributeExists, "Attribute " << name << " alrea
 
 ERS_DECLARE_ISSUE(hdf5libs, TimeSliceAlreadyExists, "The TimeSlice record for " << name << " already exists.", ((std::string)name))
 
+ERS_DECLARE_ISSUE(hdf5libs, InvalidFragmentTypeString,
+                  "Fragment type name \"" << name << "\" does not map to a valid type.", ((std::string)name))
+
+ERS_DECLARE_ISSUE(hdf5libs, InvalidSubdetectorString,
+                  "Subdetector name \"" << name << "\" does not map to a valid detector ID.", ((std::string)name))
+
 namespace hdf5libs {
 
 /**
@@ -318,6 +324,8 @@ public:
                                                                       const std::string& frag_type_name)
   {
     daqdataformats::FragmentType frag_type = daqdataformats::string_to_fragment_type(frag_type_name);
+    if (frag_type == daqdataformats::FragmentType::kUnknown)
+      throw InvalidFragmentTypeString(ERS_HERE, frag_type_name);
     return get_source_ids_for_fragment_type(rid, frag_type);
   }
   std::set<daqdataformats::SourceID> get_source_ids_for_fragment_type(const uint64_t rec_num, // NOLINT(build/unsigned)
@@ -334,9 +342,9 @@ public:
   }
 
   // get SourceIDs for given fragment type and subdetector in a record
-  std::set<daqdataformats::SourceID> get_source_ids_for_fragtype_and_detid(const record_id_t& rid,
-                                                                           const std::string& frag_type_name,
-                                                                           const std::string& subdet_name);
+  std::set<daqdataformats::SourceID> get_source_ids_for_fragtype_and_subdetector(const record_id_t& rid,
+                                                                                 const std::string& frag_type_name,
+                                                                                 const std::string& subdet_name);
 
   // get SourceIDs for given subdetector in a record
   std::set<daqdataformats::SourceID> get_source_ids_for_subdetector(const record_id_t& rid,

--- a/pybindsrc/hdf5rawdatafile.cpp
+++ b/pybindsrc/hdf5rawdatafile.cpp
@@ -161,9 +161,9 @@ register_hdf5rawdatafile(py::module& m)
          py::overload_cast<const HDF5RawDataFile::record_id_t&,const std::string&>
          (&HDF5RawDataFile::get_source_ids_for_fragment_type),
          "Get all source IDs in a record id with a given fragment type")
-    .def("get_source_ids_for_fragtype_and_detid",
+    .def("get_source_ids_for_fragtype_and_subdetector",
          py::overload_cast<const HDF5RawDataFile::record_id_t&,const std::string&,const std::string&>
-         (&HDF5RawDataFile::get_source_ids_for_fragtype_and_detid),
+         (&HDF5RawDataFile::get_source_ids_for_fragtype_and_subdetector),
          "Get all source IDs in a record id matching the specified fragment and subdetector types")
 #if 0
     .def("get_source_ids",

--- a/pybindsrc/hdf5rawdatafile.cpp
+++ b/pybindsrc/hdf5rawdatafile.cpp
@@ -157,6 +157,10 @@ register_hdf5rawdatafile(py::module& m)
          py::overload_cast<const uint64_t,const daqdataformats::sequence_number_t> //NOLINT(build/unsigned)
          (&HDF5RawDataFile::get_source_ids),
          "Get all source IDs in a record/sequence number")
+    .def("get_source_ids_for_fragtype_and_detid",
+         py::overload_cast<const HDF5RawDataFile::record_id_t&,const std::string&,const std::string&>
+         (&HDF5RawDataFile::get_source_ids_for_fragtype_and_detid),
+         "Get all source IDs in a record id matching the specified fragment and subdetector types")
 #if 0
     .def("get_source_ids",
          py::overload_cast<const HDF5RawDataFile::record_id_t&,const daqdataformats::SourceID::Subsystem>

--- a/pybindsrc/hdf5rawdatafile.cpp
+++ b/pybindsrc/hdf5rawdatafile.cpp
@@ -157,6 +157,10 @@ register_hdf5rawdatafile(py::module& m)
          py::overload_cast<const uint64_t,const daqdataformats::sequence_number_t> //NOLINT(build/unsigned)
          (&HDF5RawDataFile::get_source_ids),
          "Get all source IDs in a record/sequence number")
+    .def("get_source_ids_for_fragment_type",
+         py::overload_cast<const HDF5RawDataFile::record_id_t&,const std::string&>
+         (&HDF5RawDataFile::get_source_ids_for_fragment_type),
+         "Get all source IDs in a record id with a given fragment type")
     .def("get_source_ids_for_fragtype_and_detid",
          py::overload_cast<const HDF5RawDataFile::record_id_t&,const std::string&,const std::string&>
          (&HDF5RawDataFile::get_source_ids_for_fragtype_and_detid),

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -954,12 +954,16 @@ HDF5RawDataFile::get_source_ids_for_fragment_type(const record_id_t& rid, const 
 }
 
 std::set<daqdataformats::SourceID>
-HDF5RawDataFile::get_source_ids_for_fragtype_and_detid(const record_id_t& rid,
-                                                       const std::string& frag_type_name,
-                                                       const std::string& subdet_name)
+HDF5RawDataFile::get_source_ids_for_fragtype_and_subdetector(const record_id_t& rid,
+                                                             const std::string& frag_type_name,
+                                                             const std::string& subdet_name)
 {
   daqdataformats::FragmentType frag_type = daqdataformats::string_to_fragment_type(frag_type_name);
+  if (frag_type == daqdataformats::FragmentType::kUnknown)
+    throw InvalidFragmentTypeString(ERS_HERE, frag_type_name);
   detdataformats::DetID::Subdetector subdet = detdataformats::DetID::string_to_subdetector(subdet_name);
+  if (subdet == detdataformats::DetID::Subdetector::kUnknown)
+    throw InvalidSubdetectorString(ERS_HERE, subdet_name);
 
   auto rec_id = get_all_record_ids().find(rid);
   if (rec_id == get_all_record_ids().end())

--- a/src/HDF5RawDataFile.cpp
+++ b/src/HDF5RawDataFile.cpp
@@ -945,6 +945,31 @@ HDF5RawDataFile::get_source_ids_for_fragment_type(const record_id_t& rid, const 
 }
 
 std::set<daqdataformats::SourceID>
+HDF5RawDataFile::get_source_ids_for_fragtype_and_detid(const record_id_t& rid,
+                                                       const std::string& frag_type_name,
+                                                       const std::string& subdet_name)
+{
+  daqdataformats::FragmentType frag_type = daqdataformats::string_to_fragment_type(frag_type_name);
+  detdataformats::DetID::Subdetector subdet = detdataformats::DetID::string_to_subdetector(subdet_name);
+
+  auto rec_id = get_all_record_ids().find(rid);
+  if (rec_id == get_all_record_ids().end())
+    throw RecordIDNotFound(ERS_HERE, rid.first, rid.second);
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  std::set<daqdataformats::SourceID> fragtype_match_sids = m_fragment_type_source_id_cache[rid][frag_type];
+  std::set<daqdataformats::SourceID> detid_match_sids = m_subdetector_source_id_cache[rid][subdet];
+  std::set<daqdataformats::SourceID> combined_set_sids;
+  for (auto ftsid : fragtype_match_sids) {
+    if (detid_match_sids.contains(ftsid)) {
+      combined_set_sids.insert(ftsid);
+    }
+  }
+  return combined_set_sids;
+}
+
+std::set<daqdataformats::SourceID>
 HDF5RawDataFile::get_source_ids_for_subdetector(const record_id_t& rid, const detdataformats::DetID::Subdetector subdet)
 {
   auto rec_id = get_all_record_ids().find(rid);
@@ -959,7 +984,6 @@ HDF5RawDataFile::get_source_ids_for_subdetector(const record_id_t& rid, const de
 std::unique_ptr<char[]>
 HDF5RawDataFile::get_dataset_raw_data(const std::string& dataset_path)
 {
-
   HighFive::Group parent_group = m_file_ptr->getGroup("/");
   HighFive::DataSet data_set = parent_group.getDataSet(dataset_path);
 

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -218,6 +218,17 @@ main(int argc, char** argv)
            << static_cast<int>(tcptr->data.algorithm) << ", number of TAs = " << tcptr->n_inputs;
         ss << "\n\t\t" << "First TC start time=" << tcptr->data.time_start << ", end time=" << tcptr->data.time_end
            << ", and candidate time=" << tcptr->data.time_candidate;
+        if (number_of_TCs >= 2) {
+          offset = sizeof(TriggerCandidateData) + sizeof(tcptr->n_inputs);
+          offset += (tcptr->n_inputs * sizeof(TriggerActivityData));
+          TriggerCandidate* tmp_tcptr =
+            reinterpret_cast<TriggerCandidate*>(offset+reinterpret_cast<uint8_t*>(frag_ptr->get_data()));
+          ss << "\n\t\t" << "Second TC type = " << get_trigger_candidate_type_names()[tmp_tcptr->data.type]
+             << " (" << static_cast<int>(tmp_tcptr->data.type) << "), TC algorithm = "
+             << static_cast<int>(tmp_tcptr->data.algorithm) << ", number of TAs = " << tmp_tcptr->n_inputs;
+          ss << "\n\t\t" << "Second TC start time=" << tmp_tcptr->data.time_start << ", end time=" << tmp_tcptr->data.time_end
+             << ", and candidate time=" << tmp_tcptr->data.time_candidate;
+        }
       }
       if (frag_ptr->get_fragment_type() == FragmentType::kTriggerActivity) {
         size_t payload_size = frag_ptr->get_size() - sizeof(FragmentHeader);
@@ -240,6 +251,16 @@ main(int argc, char** argv)
            << static_cast<int>(taptr->data.algorithm) << ", number of TPs = " << taptr->n_inputs;
         ss << "\n\t\t" << "First TA start time=" << taptr->data.time_start << ", end time=" << taptr->data.time_end
            << ", and activity time=" << taptr->data.time_activity;
+        if (number_of_TAs >= 2) {
+          offset = sizeof(TriggerActivityData) + sizeof(taptr->n_inputs);
+          offset += (taptr->n_inputs * sizeof(TriggerPrimitive));
+          TriggerActivity* tmp_taptr =
+            reinterpret_cast<TriggerActivity*>(offset+reinterpret_cast<uint8_t*>(frag_ptr->get_data()));
+          ss << "\n\t\t" << "Second TA type = " << static_cast<int>(tmp_taptr->data.type) << ", TA algorithm = "
+             << static_cast<int>(tmp_taptr->data.algorithm) << ", number of TPs = " << tmp_taptr->n_inputs;
+          ss << "\n\t\t" << "Second TA start time=" << tmp_taptr->data.time_start << ", end time=" << tmp_taptr->data.time_end
+             << ", and activity time=" << tmp_taptr->data.time_activity;
+        }
       }
       if (frag_ptr->get_fragment_type() == FragmentType::kTriggerPrimitive) {
         ss << "\n\t\t" << "Number of TPs in this fragment="


### PR DESCRIPTION
This PR has code changes that are needed for some data-file-check improvements in our integrationtest infrastructure.  That is, the addition of the `get_source_ids_for_fragtype_and_subdetector()` function.  This function will allow us to look up fragments by both fragment type and subdetector type, if/when that is needed.

There are also some minor additions to the HDF5LIBS_TestDumpRecord app that are not strictly needed but were useful during testing.

The code changes in this PR can be tested and merged independently of other changes, but they are a necessary building block for changes in the `integrationtest` package.