### PR TITLE
Added a couple more human-understandable timestamp printouts to HDF5LIBS_TestDumpRecord

### DIFF
--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -209,6 +209,12 @@ main(int argc, char** argv)
           ss << "\n\t\t"
              << "Readout window begin = " << begin_diff << ", end = " << end_diff
              << " (relative to the trigger_timestamp)";
+          if (print_calendar_time) {
+            std::string window_begin_string = get_calendar_time_string(cr.window_begin);
+            std::string window_end_string = get_calendar_time_string(cr.window_end);
+            ss << "\n\t\t\t"
+               << "Readout window times corresponds to UTC " << window_begin_string << " and " << window_end_string;
+          }
         } catch (std::exception const& excpt) {
           ss << "\n\t\t"
              << "Unable to determine readout window, exception was \"" << excpt.what() << "\"";

--- a/test/apps/HDF5LIBS_TestDumpRecord.cpp
+++ b/test/apps/HDF5LIBS_TestDumpRecord.cpp
@@ -177,6 +177,11 @@ main(int argc, char** argv)
         std::exit(1);
       }
       ss << "\n\tTriggerRecordHeader: " << trh_ptr->get_header();
+      if (print_calendar_time) {
+        std::string trigger_timestamp_string = get_calendar_time_string(trh_ptr->get_header().trigger_timestamp);
+        ss << "\n\t\t"
+           << "Trigger timestamp corresponds to UTC " << trigger_timestamp_string;
+      }
     }
     TLOG() << ss.str();
     ss.str("");


### PR DESCRIPTION
The new printouts are for the trigger_timestamp in the TriggerRecordHeader and the readout window begin and end times in TriggerRecord Fragments.

As before, these are enabled with the "-t" command-line option.
