### PR TITLE
Updated the hdf5_dump.py script to accept file layout version 7, and …

### DIFF
--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -9,7 +9,7 @@ import sys
 
 # Current allowed range of file layout versions
 FILELAYOUT_MIN_VERSION = 4
-FILELAYOUT_MAX_VERSION = 6
+FILELAYOUT_MAX_VERSION = 7
 
 # Current header versions
 TRIGGER_RECORD_HEADER_VERSION = 4
@@ -87,7 +87,7 @@ class DAQDataFile:
                 observed_filelayout_version <= FILELAYOUT_MAX_VERSION:
             print(f"INFO: input file \"{self.name}\" matches the supported file layout versions: {FILELAYOUT_MIN_VERSION} <= {observed_filelayout_version} <= {FILELAYOUT_MAX_VERSION}")
         else:
-            sys.exit(f"ERROR: this script expects a file layout version {FILELAYOUT_VERSION} but this wasn't confirmed in the HDF5 file \"{self.name}\"")
+            sys.exit(f"ERROR: this script expects a file layout version between {FILELAYOUT_MIN_VERSION} and {FILELAYOUT_MAX_VERSION} but this wasn't confirmed in the HDF5 file \"{self.name}\", version={observed_filelayout_version}")
         if 'record_type' in self.h5file.attrs.keys():
             self.record_type = self.h5file.attrs['record_type']
         for i in self.h5file.keys():


### PR DESCRIPTION
…fixed a bug in the error message when an unsupported file layout version is found in a data file.

Wes had noticed the bug when trying to run the existing version of this script on a raw data file written at NP02 with the latest software.  That software had FILELAYOUT_VERSION of 7, but the script was only allowing versions 4-6.  (Recall that the changes included in FILE_LAYOUT version 7 were just a couple of HDF5 file Attributes to report information associated with HDF5 compression.