### PR TITLE
Updated hdf5_dump.py for new TriggerRecordHeader version, new FragmentHeader…

### DIFF
--- a/scripts/hdf5_dump.py
+++ b/scripts/hdf5_dump.py
@@ -15,8 +15,8 @@ FILELAYOUT_MIN_VERSION = 4
 FILELAYOUT_MAX_VERSION = 7
 
 # Current header versions
-TRIGGER_RECORD_HEADER_VERSION = 4
-FRAGMENT_HEADER_VERSION = 5
+TRIGGER_RECORD_HEADER_VERSION = 5
+FRAGMENT_HEADER_VERSION = 6
 TIME_SLICE_HEADER_VERSION = 2
 
 DATA_FORMAT = {
@@ -32,7 +32,7 @@ DATA_FORMAT = {
     "TriggerRecord Header": {
         "keys": ['Marker word', 'Version', 'Trigger number',                       # I I Q
                  'Trigger timestamp', 'No. of requested components', 'Run number', # Q Q I
-                 'Error bits', 'Trigger type', 'Sequence number',                  # I Q H
+                 'Status bits', 'Trigger type', 'Sequence number',                  # I Q H
                  'Max sequence num', 'Padding',                                    # H I
                  'Source ID version', 'Source ID subsystem', 'Source ID'],         # H H I
         "size": 64,
@@ -42,7 +42,7 @@ DATA_FORMAT = {
     "Fragment Header":{
         "keys": ['Marker word', 'Version', 'Fragment size', 'Trigger number',      # I I Q Q
                  'Trigger timestamp', 'Window begin', 'Window end', 'Run number',  # Q Q Q I
-                 'Error bits', 'Fragment type', 'Sequence number',                 # I I H
+                 'Status bits', 'Fragment type', 'Sequence number',                 # I I H
                  'Detector',                                                       # H
                  'Source ID version', 'Source ID subsystem', 'Source ID'],         # H H I
         "size": 72,
@@ -237,6 +237,8 @@ def print_header_dict(hdict, clock_speed_hz):
             print("{:<30}: {} ({})".format(
                 ik, iv, tick_to_timestamp(iv, clock_speed_hz)))
         elif 'Marker word' in ik:
+            print("{:<30}: {}".format(ik, hex(iv)))
+        elif 'Status bits' in ik:
             print("{:<30}: {}".format(ik, hex(iv)))
         elif ik == 'Detector':
             subdet = detdataformats.DetID.Subdetector(iv)


### PR DESCRIPTION
… version, and new name for error bits (now status bits).

# Description

I also changed the display of the status bits to be in Hex, to help make it easier to understand which bits are set.

Main PR: https://github.com/DUNE-DAQ/daqdataformats/pull/78
Issue: https://github.com/DUNE-DAQ/daqdataformats/issues/66

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
