### PR TITLE
Switch `HDF5RawDataFile` Init From String to Filesystem Path

### DIFF
--- a/pybindsrc/hdf5rawdatafile.cpp
+++ b/pybindsrc/hdf5rawdatafile.cpp
@@ -10,6 +10,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
 #include <pybind11/stl_bind.h>
 
 #include <string>
@@ -25,7 +26,7 @@ register_hdf5rawdatafile(py::module& m)
 {
 
   py::class_<HDF5RawDataFile>(m, "_HDF5RawDataFile")
-    .def(py::init<std::string>())
+    .def(py::init<std::filesystem::path>())
 
     .def("get_attribute_names",
          &HDF5RawDataFile::get_attribute_names,


### PR DESCRIPTION
# Description
I've replaced the string-based PyBind11 initialization of `HDF5RawDataFile` with PyBind11 (std) `filesystem::path`. PyBind11 supports automatic conversions between Python's `pathlib.Path` and C++'s `std::filesystem::path`. This allows users/developers to use `pathlib.Path` and not require them to convert by `str()` before initializing `HDF5RawDataFile` in Python scripts.

Since this change only affects the Pythonic `HDF5RawDataFile`, testing was done by passing an argument to open a file with various formats:
```python
from hdf5libs import HDF5RawDataFile
from pathlib import Path

file_path_str = "<path_to_some_file>"
file_path = Path(file_path_str)

try:
    h5_file = HDF5RawDataFile(file_path_str)
    print("Opened file using string-path.  File's run number =", h5_file.get_int_attribute("run_number"))
except TypeError as e:
    print("Use of string-paths are not supported\n")
    raise e

try:
    h5_file = HDF5RawDataFile(file_path)
    print("Opened file using pathlib.Path. File's run number =", h5_file.get_int_attribute("run_number"))
except TypeError as e:
    print("Use of pathlib.Path is not supported\n")
    raise e
```

Before the change, the second case would raise an exception. After the change, neither case would raise an exception.

This change should not affect more crucial systems since this is purely a PyBind11/Pythonic change. It is also a _very_ low priority change.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

