### PR TITLE
Set default `USER` environment variable in unit test fixture

### DIFF
--- a/unittest/HDF5WriteReadTimeSlice_test.cxx
+++ b/unittest/HDF5WriteReadTimeSlice_test.cxx
@@ -153,9 +153,9 @@ struct FileWriteFixture
       compression_level(comp_lvl),
       file_path(std::filesystem::temp_directory_path()),
       hdf5_filename(
-        "demo" + std::to_string(getpid()) + "_" 
-        + std::string(getenv("USER")) + "_comp" 
-        + std::to_string(compression_level) + ".hdf5"),
+        "demo" + std::to_string(getpid()) + "_"
+        + std::string(getenv("USER") ? getenv("USER") : "") +
+        + "_comp" + std::to_string(compression_level) + ".hdf5"),
       fl_pars(create_file_layout_params()),
       recorded_size_at_write(0)
   {

--- a/unittest/HDF5WriteReadTriggerRecord_test.cxx
+++ b/unittest/HDF5WriteReadTriggerRecord_test.cxx
@@ -250,12 +250,16 @@ struct FileWriteFixture
     : trigger_count(num_triggers)
     , compression_level(comp_lvl)
     , file_path(std::filesystem::temp_directory_path())
-    , hdf5_filename("demo" + std::to_string(getpid()) + "_" + std::string(getenv("USER")) + "_comp" +
+    , hdf5_filename("demo" + std::to_string(getpid()) + "_" + 
+                    std::string(getenv("USER") ? getenv("USER") : "") + "_comp" +
                     std::to_string(compression_level) + ".hdf5")
     , fl_pars(create_file_layout_params())
     , recorded_size_at_write(0)
   {
     delete_files_matching_pattern(file_path, hdf5_filename);
+
+    BOOST_TEST_MESSAGE("file_path: " << file_path);
+    BOOST_TEST_MESSAGE("hdf5_filename: " << hdf5_filename);
 
     // create src-geo id map
     auto srcid_geoid_map = create_srcid_geoid_map();

--- a/unittest/HDF5WriteReadTriggerRecord_test.cxx
+++ b/unittest/HDF5WriteReadTriggerRecord_test.cxx
@@ -251,8 +251,8 @@ struct FileWriteFixture
     , compression_level(comp_lvl)
     , file_path(std::filesystem::temp_directory_path())
     , hdf5_filename("demo" + std::to_string(getpid()) + "_" + 
-                    std::string(getenv("USER") ? getenv("USER") : "") + "_comp" +
-                    std::to_string(compression_level) + ".hdf5")
+                    std::string(getenv("USER") ? getenv("USER") : "") +
+                    "_comp" + std::to_string(compression_level) + ".hdf5")
     , fl_pars(create_file_layout_params())
     , recorded_size_at_write(0)
   {

--- a/unittest/HDF5WriteReadTriggerRecord_test.cxx
+++ b/unittest/HDF5WriteReadTriggerRecord_test.cxx
@@ -258,9 +258,6 @@ struct FileWriteFixture
   {
     delete_files_matching_pattern(file_path, hdf5_filename);
 
-    BOOST_TEST_MESSAGE("file_path: " << file_path);
-    BOOST_TEST_MESSAGE("hdf5_filename: " << hdf5_filename);
-
     // create src-geo id map
     auto srcid_geoid_map = create_srcid_geoid_map();
     // create the file


### PR DESCRIPTION
# Description

I'm working on running unit tests inside a Docker image spun off the nightly build container. In doing so, I noticed that the `hdf5libs` unit tests all fail due to the `USER` environment variable not being set in a Docker container. This means that the `FileWriteFixture` container receives null input, leading to errors:
```c++
hdf5_filename(
  "demo" + std::to_string(getpid()) + "_" 
   + std::string(getenv("USER")) + "_comp" 
   + std::to_string(compression_level) + ".hdf5"),
```

This PR has the constructor check for the existence of `USER` first and set it to an empty string if it doesn't exist.

To reproduce this issue, try running `dbt-build --unittest hdf5libs` in the nightly build container with `hdf5libs` checked out:

```bash
docker pull ghcr.io/dune-daq/nightly-release-alma9:development_v5
docker run --rm -it ghcr.io/dune-daq/nightly-release-alma9:development_v5
# The following commands are run inside the container:
cd home
source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n last_fddaq
cd NFD_DEV_260629A_9 # Or whatever 'last_fddaq' resolves to
source env.sh
cd sourcecode
git clone https://github.com/DUNE-DAQ/hdf5libs.git
dbt-build --unittest
```

You'll see a bunch of errors complaining about null input in the `FileWriteFixture`. Then, still inside the container, you can checkout this branch to confirm the problem is resolved:
```bash
# Still inside the container in hdf5libs path
git switch amogan/default_user_environment_variable
dbt-build --unittest
```

The tests should now succeed. 

Another option is to simply add `-e USER=$(whoami)` to the `docker run` command. But the goal here is to have unit tests run in the single-repo CI workflows, and I would rather not have to handle special cases per repo.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

